### PR TITLE
Add backend SQL schema

### DIFF
--- a/Backend/config_server.md
+++ b/Backend/config_server.md
@@ -31,6 +31,16 @@ This document outlines how the backend database server was set up and how to con
    GRANT ALL PRIVILEGES ON DATABASE ares TO ares;
    ```
 
+   If you later see `permission denied for table assets`, grant the user
+   privileges to all tables and sequences:
+
+   ```sql
+   GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ares;
+   GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ares;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ares;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ares;
+   ```
+
 5. Allow port 5432 through the firewall (if active):
    ```bash
    sudo ufw allow 5432/tcp

--- a/Backend/sql_schema.sql
+++ b/Backend/sql_schema.sql
@@ -1,0 +1,57 @@
+-- === Grundelemente ===
+CREATE TABLE assets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    type TEXT CHECK (type IN ('ground', 'air')) NOT NULL,
+    status TEXT,
+    battery FLOAT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE asset_components (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    asset_id UUID REFERENCES assets(id) ON DELETE CASCADE,
+    type TEXT CHECK (type IN ('camera', 'sensor', 'actor')) NOT NULL,
+    model TEXT,
+    position TEXT,
+    data JSONB,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- === Taskverwaltung ===
+CREATE TABLE tasks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title TEXT NOT NULL,
+    priority INTEGER CHECK (priority BETWEEN 1 AND 5),
+    created_at TIMESTAMP DEFAULT NOW(),
+    is_active BOOLEAN DEFAULT true
+);
+
+CREATE TABLE asset_task_assignments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    asset_id UUID REFERENCES assets(id) ON DELETE CASCADE,
+    task_id UUID REFERENCES tasks(id) ON DELETE CASCADE,
+    assigned_at TIMESTAMP DEFAULT NOW(),
+    state TEXT CHECK (state IN ('assigned', 'in_progress', 'done')) DEFAULT 'assigned'
+);
+
+-- === Kartierung / Grid ===
+CREATE TABLE environment_map (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    width INTEGER,
+    height INTEGER,
+    grid JSONB,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- === Bewegungsdaten / Log ===
+CREATE TABLE asset_log (
+    id SERIAL PRIMARY KEY,
+    asset_id UUID REFERENCES assets(id) ON DELETE CASCADE,
+    pos_x INTEGER,
+    pos_y INTEGER,
+    orientation TEXT,
+    timestamp TIMESTAMP DEFAULT NOW(),
+    source TEXT
+);


### PR DESCRIPTION
## Summary
- document database tables in `sql_schema.sql` for backend setup
- expand configuration notes with table privilege commands

## Testing
- `javac Environment/*.java Terminal/*.java` *(fails: package org.jline.* not found)*
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846dd34487c83319f58e9628afb0fd6