### PR TITLE
Add Flask API and frontend upload

### DIFF
--- a/Backend/map_api.py
+++ b/Backend/map_api.py
@@ -1,0 +1,38 @@
+from flask import Flask, request, jsonify
+import psycopg2
+import uuid
+import json
+import os
+
+app = Flask(__name__)
+
+
+def get_conn():
+    return psycopg2.connect(
+        host=os.getenv("DB_HOST", "localhost"),
+        port=os.getenv("DB_PORT", "5432"),
+        dbname=os.getenv("DB_NAME", "ares"),
+        user=os.getenv("DB_USER", "ares"),
+        password=os.getenv("DB_PASSWORD", "ares"),
+    )
+
+
+@app.route('/api/maps', methods=['POST'])
+def save_map():
+    data = request.get_json()
+    if not data or 'name' not in data or 'map' not in data:
+        return jsonify({'error': 'invalid payload'}), 400
+    conn = get_conn()
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO maps (id, name, data) VALUES (%s, %s, %s)",
+                (str(uuid.uuid4()), data['name'], json.dumps(data['map']))
+            )
+        return jsonify({'status': 'ok'})
+    finally:
+        conn.close()
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+psycopg2-binary

--- a/Backend/sql_schema.sql
+++ b/Backend/sql_schema.sql
@@ -55,3 +55,11 @@ CREATE TABLE asset_log (
     timestamp TIMESTAMP DEFAULT NOW(),
     source TEXT
 );
+
+-- === Maps API ===
+CREATE TABLE maps (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    data JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT now()
+);

--- a/README.md
+++ b/README.md
@@ -22,3 +22,32 @@ Open `frontend/index.html` in a browser to try it out. No backend connectivity i
 ## Backend
 
 The `Backend` folder documents how to set up a PostgreSQL server and how the Java client connects to it. See `Backend/config_server.md` for the step-by-step instructions used in the home lab.
+
+## Flask Map API Example
+
+A small Flask application is provided in `Backend/map_api.py` to store maps in PostgreSQL.
+Install dependencies with:
+
+```bash
+pip install -r Backend/requirements.txt
+```
+
+Start the server:
+
+```bash
+python Backend/map_api.py
+```
+
+It expects a table `maps` with the following schema:
+
+```sql
+CREATE TABLE maps (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    data JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT now()
+);
+```
+
+Send a `POST` request to `/api/maps` with JSON
+`{"name": "Map A", "map": {...}}` to save a map.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -83,6 +83,7 @@ function init() {
   document.getElementById('toggleView').addEventListener('click', toggleView);
   document.getElementById('calcPath').addEventListener('click', calculatePath);
   document.getElementById('saveMap').addEventListener('click', saveMap);
+  document.getElementById('saveMapDb').addEventListener('click', uploadMap);
   document.getElementById('loadMapBtn').addEventListener('click', () => document.getElementById('loadMap').click());
   document.getElementById('loadMap').addEventListener('change', loadMap);
   document.getElementById('assetSelect').addEventListener('change', e => {
@@ -285,19 +286,40 @@ function bfs(asset, targets) {
   return null;
 }
 
-function saveMap() {
-  const data = {
+function getCurrentMapData() {
+  return {
     width: state.map.width,
     height: state.map.height,
     cells: state.map.cells,
     assets: state.assets.map(a => ({id: a.id, x: a.x, y: a.y, battery: a.battery, taskId: a.taskId})),
     tasks: state.tasks.map(t => ({id: t.id, description: t.description, assignedAssetId: t.assignedAssetId}))
   };
+}
+
+function saveMap() {
+  const data = getCurrentMapData();
   const blob = new Blob([JSON.stringify(data)], {type: 'application/json'});
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);
   link.download = 'map.json';
   link.click();
+}
+
+function uploadMap() {
+  const name = document.getElementById('mapName').value.trim();
+  if (!name) {
+    alert('Enter map name');
+    return;
+  }
+  const data = getCurrentMapData();
+  fetch('/api/maps', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({name: name, map: data})
+  }).then(res => {
+    if (res.ok) alert('Gespeichert');
+    else alert('Fehler beim Speichern');
+  });
 }
 
 function loadMap(e) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,9 @@
       </label>
       <button id="toggleView">POV Mode</button>
       <button id="calcPath">Calc Path</button>
-      <button id="saveMap">Save Map</button>
+      <input type="text" id="mapName" placeholder="Map name">
+      <button id="saveMapDb">Save Map</button>
+      <button id="saveMap">Download Map</button>
       <button id="loadMapBtn">Load Map</button>
       <input type="file" id="loadMap" style="display:none" accept="application/json">
     </div>


### PR DESCRIPTION
## Summary
- create `Backend/map_api.py` Flask server for saving maps to PostgreSQL
- note dependencies in `Backend/requirements.txt`
- document the server usage in README
- extend SQL schema with `maps` table
- add map name field and upload button to the frontend
- implement API call in `frontend/app.js`

## Testing
- `python -m py_compile Backend/map_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e6be89548331aed3b74b7ca19c30