### PR TITLE
Add asset editing and deletion

### DIFF
--- a/Backend/asset_api.py
+++ b/Backend/asset_api.py
@@ -60,5 +60,49 @@ def get_asset(asset_id):
     finally:
         conn.close()
 
+
+@app.route('/api/assets/<asset_id>', methods=['DELETE'])
+def delete_asset(asset_id):
+    conn = get_conn()
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute("DELETE FROM assets WHERE id = %s", (asset_id,))
+            if cur.rowcount == 0:
+                return jsonify({"error": "not found"}), 404
+        return jsonify({"status": "deleted"})
+    finally:
+        conn.close()
+
+
+@app.route('/api/assets/<asset_id>', methods=['PUT'])
+def update_asset(asset_id):
+    data = request.get_json() or {}
+    fields = []
+    values = []
+    if 'name' in data:
+        fields.append('name = %s')
+        values.append(data['name'])
+    if 'type' in data:
+        fields.append('type = %s')
+        values.append(data['type'])
+    if 'status' in data:
+        fields.append('status = %s')
+        values.append(data['status'])
+    if 'battery' in data:
+        fields.append('battery = %s')
+        values.append(data['battery'])
+    if not fields:
+        return jsonify({'error': 'no fields to update'}), 400
+    values.append(asset_id)
+    conn = get_conn()
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute(f"UPDATE assets SET {', '.join(fields)} WHERE id = %s", values)
+            if cur.rowcount == 0:
+                return jsonify({"error": "not found"}), 404
+        return jsonify({"status": "ok"})
+    finally:
+        conn.close()
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/README.md
+++ b/README.md
@@ -51,3 +51,20 @@ CREATE TABLE maps (
 
 Send a `POST` request to `/api/maps` with JSON
 `{"name": "Map A", "map": {...}}` to save a map.
+
+## Flask Asset API
+
+`Backend/asset_api.py` provides CRUD endpoints for managing assets.
+Run the server with:
+
+```bash
+python Backend/asset_api.py
+```
+
+Available routes:
+
+- `POST /api/assets` – create an asset
+- `GET /api/assets` – list assets
+- `GET /api/assets/<id>` – fetch one asset
+- `PUT /api/assets/<id>` – update fields of an asset
+- `DELETE /api/assets/<id>` – remove an asset

--- a/frontend/asset/asset.js
+++ b/frontend/asset/asset.js
@@ -33,10 +33,55 @@ function loadAssets() {
       data.forEach(asset => {
         const div = document.createElement('div');
         div.className = 'asset-item';
-        div.textContent = `ID: ${asset.id} | Name: ${asset.name} | Typ: ${asset.type} | Status: ${asset.status} | Batterie: ${asset.battery}%`;
+        const info = document.createElement('span');
+        info.textContent = `ID: ${asset.id} | Name: ${asset.name} | Typ: ${asset.type} | Status: ${asset.status} | Batterie: ${asset.battery}%`;
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Bearbeiten';
+        editBtn.style.marginLeft = '10px';
+        editBtn.onclick = () => editAsset(asset);
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Löschen';
+        delBtn.style.marginLeft = '5px';
+        delBtn.onclick = () => deleteAsset(asset.id);
+        div.appendChild(info);
+        div.appendChild(editBtn);
+        div.appendChild(delBtn);
         list.appendChild(div);
       });
     });
 }
 
 window.onload = loadAssets;
+
+function deleteAsset(id) {
+  if (!confirm('Asset wirklich löschen?')) return;
+  fetch(`http://127.0.0.1:5000/api/assets/${id}`, { method: 'DELETE' })
+    .then(res => {
+      if (!res.ok) throw new Error('Fehler beim Löschen');
+      return res.json();
+    })
+    .then(() => loadAssets())
+    .catch(err => alert(err.message));
+}
+
+function editAsset(asset) {
+  const name = prompt('Name', asset.name);
+  if (name === null) return;
+  const type = prompt('Typ (ground/air)', asset.type);
+  if (type === null) return;
+  const status = prompt('Status', asset.status);
+  if (status === null) return;
+  const battery = prompt('Batterie', asset.battery);
+  if (battery === null) return;
+  fetch(`http://127.0.0.1:5000/api/assets/${asset.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, type, status, battery: parseFloat(battery) })
+  })
+    .then(res => {
+      if (!res.ok) throw new Error('Fehler beim Aktualisieren');
+      return res.json();
+    })
+    .then(() => loadAssets())
+    .catch(err => alert(err.message));
+}


### PR DESCRIPTION
## Summary
- extend asset_api with PUT and DELETE routes
- enhance asset frontend to edit and delete items
- document the asset API in README

## Testing
- `python -m py_compile Backend/asset_api.py Backend/map_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f49ddb208331a8c7bb415c7c1e9d