### PR TITLE
Add map size controls

### DIFF
--- a/frontend/map/app.js
+++ b/frontend/map/app.js
@@ -90,6 +90,7 @@ function init() {
   document.getElementById('fetchMaps').addEventListener('click', fetchAvailableMaps);
   document.getElementById('renameMapBtn').addEventListener('click', renameMap);
   document.getElementById('deleteMapBtn').addEventListener('click', deleteMap);
+  document.getElementById('setSizeBtn').addEventListener('click', resizeMap);
   document.getElementById('assetSelect').addEventListener('change', e => {
     state.selectedAssetId = e.target.value;
   });
@@ -133,6 +134,22 @@ function setGridSize(width, height) {
   const root = document.documentElement;
   root.style.setProperty('--grid-width', width);
   root.style.setProperty('--grid-height', height);
+}
+
+function resizeMap() {
+  const w = parseInt(document.getElementById('gridWidth').value, 10);
+  const h = parseInt(document.getElementById('gridHeight').value, 10);
+  if (isNaN(w) || isNaN(h) || w <= 0 || h <= 0) {
+    alert('Invalid size');
+    return;
+  }
+  state.map = new GridMap(w, h);
+  setGridSize(w, h);
+  state.activeAssetId = null;
+  state.path = [];
+  renderGrid();
+  updateAssetList();
+  updateTaskList();
 }
 
 function getAllCells() {

--- a/frontend/map/index.html
+++ b/frontend/map/index.html
@@ -23,6 +23,11 @@
       </label>
       <button id="toggleView">POV Mode</button>
       <button id="calcPath">Calc Path</button>
+      <label>Size:
+        <input id="gridWidth" type="number" value="20" min="1" style="width:60px"> x
+        <input id="gridHeight" type="number" value="20" min="1" style="width:60px">
+      </label>
+      <button id="setSizeBtn">Set Size</button>
       <input type="text" id="mapName" placeholder="Map name">
       <button id="saveMapDb">Save Map</button>
   <select id="mapSelect"></select>


### PR DESCRIPTION
## Summary
- allow configuring grid dimensions from the toolbar
- implement `resizeMap()` in the frontend JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f529ede0833198ff1cdbff2d39d7