### PR TITLE
Add dynamic target and pathfinding

### DIFF
--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -95,6 +95,7 @@
     import { Car } from './car.js'
     import { Obstacle } from './obstacle.js'
     import { GameMap } from './map.js'
+    import { aStar } from './pathfinder.js'
 
     const canvas = document.getElementById('canvas')
     const ctx = canvas.getContext('2d')
@@ -117,6 +118,7 @@
     let dragX = 0
     let dragY = 0
     let taskMarker = gameMap.task
+    let path = []
 
     const carImage = new Image()
     carImage.src = 'extracted_foreground.png'
@@ -159,11 +161,13 @@
       } else if (selected === 'task') {
         taskMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
         gameMap.task = taskMarker
+        computePath()
       } else {
         obstacles.push(new Obstacle(dragX, dragY, previewSize))
       }
 
       isDragging = false
+      computePath()
     })
 
     canvas.addEventListener('mousemove', e => {
@@ -208,6 +212,40 @@
         }
       }
       generateBorder()
+      computePath()
+    }
+
+    function placeRandomTarget() {
+      let x, y, px, py, coll
+      do {
+        x = Math.floor(Math.random() * gameMap.cols)
+        y = Math.floor(Math.random() * gameMap.rows)
+        px = x * CELL_SIZE
+        py = y * CELL_SIZE
+        coll = obstacles.some(o =>
+          px + CELL_SIZE/2 >= o.x && px + CELL_SIZE/2 <= o.x + o.size &&
+          py + CELL_SIZE/2 >= o.y && py + CELL_SIZE/2 <= o.y + o.size)
+      } while (coll)
+      taskMarker = { x: px + CELL_SIZE/2, y: py + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
+      gameMap.task = taskMarker
+    }
+
+    function computePath() {
+      if (!taskMarker) { path = []; return }
+      const start = {
+        x: Math.floor((car.posX + car.imgWidth/2) / CELL_SIZE),
+        y: Math.floor((car.posY + car.imgHeight/2) / CELL_SIZE)
+      }
+      const goal = {
+        x: Math.floor(taskMarker.x / CELL_SIZE),
+        y: Math.floor(taskMarker.y / CELL_SIZE)
+      }
+      const cells = aStar(start, goal, gameMap.cols, gameMap.rows, obstacles, CELL_SIZE)
+      if (cells) {
+        path = cells.map(c => ({ x: c.x * CELL_SIZE + CELL_SIZE/2, y: c.y * CELL_SIZE + CELL_SIZE/2 }))
+      } else {
+        path = []
+      }
     }
 
     generateMazeBtn.addEventListener('click', generateMaze)
@@ -233,12 +271,31 @@
       drawGrid()
       for (const o of obstacles) o.draw(ctx)
       if (taskMarker) {
-        ctx.fillStyle='green'; ctx.beginPath(); ctx.arc(taskMarker.x, taskMarker.y, taskMarker.radius,0,Math.PI*2); ctx.fill()
+        ctx.fillStyle='green';
+        ctx.beginPath();
+        ctx.arc(taskMarker.x, taskMarker.y, taskMarker.radius,0,Math.PI*2);
+        ctx.fill()
+      }
+      computePath()
+      if (path.length > 1) {
+        ctx.strokeStyle = 'orange'
+        ctx.lineWidth = 3
+        ctx.beginPath()
+        ctx.moveTo(path[0].x, path[0].y)
+        for (const p of path.slice(1)) ctx.lineTo(p.x, p.y)
+        ctx.stroke()
       }
       if (isDragging && dropdown.value!=='task' && !removeCheckbox.checked) {
         ctx.strokeStyle='red'; ctx.lineWidth=2; ctx.strokeRect(dragX, dragY, previewSize, previewSize)
       }
       car.update(canvas.width, canvas.height)
+
+      if (taskMarker &&
+          taskMarker.x >= car.posX && taskMarker.x <= car.posX + car.imgWidth &&
+          taskMarker.y >= car.posY && taskMarker.y <= car.posY + car.imgHeight) {
+        placeRandomTarget()
+        computePath()
+      }
 
       redEl.textContent = Math.round(car.redConeLength)
       greenEl.textContent = Math.round(car.greenConeLength)
@@ -313,6 +370,7 @@
         document.getElementById('gridWidth').value = gameMap.cols
         document.getElementById('gridHeight').value = gameMap.rows
         resizeCanvas()
+        computePath()
       }
       reader.readAsText(file)
     }
@@ -346,6 +404,7 @@
           document.getElementById('gridWidth').value = gameMap.cols
           document.getElementById('gridHeight').value = gameMap.rows
           resizeCanvas()
+          computePath()
         })
     }
 
@@ -385,9 +444,10 @@
       car.objects = obstacles
       resizeCanvas()
       generateBorder()
+      computePath()
     }
 
-    carImage.onload = () => { resizeCanvas(); fetchAvailableMaps(); loop() }
+    carImage.onload = () => { resizeCanvas(); fetchAvailableMaps(); computePath(); loop() }
   </script>
 </body>
 </html>

--- a/SimulateAsset/pathfinder.js
+++ b/SimulateAsset/pathfinder.js
@@ -1,0 +1,54 @@
+export function aStar(start, goal, cols, rows, obstacles, cellSize) {
+  const toKey = (x, y) => `${x},${y}`
+  const fromKey = k => k.split(',').map(n => parseInt(n, 10))
+  const blocked = new Set()
+  for (const o of obstacles) {
+    const ox = o.x / cellSize
+    const oy = o.y / cellSize
+    const size = Math.ceil(o.size / cellSize)
+    for (let dx = 0; dx < size; dx++) {
+      for (let dy = 0; dy < size; dy++) {
+        blocked.add(toKey(ox + dx, oy + dy))
+      }
+    }
+  }
+  const startKey = toKey(start.x, start.y)
+  const goalKey = toKey(goal.x, goal.y)
+  const open = [startKey]
+  const openSet = new Set(open)
+  const came = {}
+  const g = { [startKey]: 0 }
+  const f = { [startKey]: Math.abs(goal.x - start.x) + Math.abs(goal.y - start.y) }
+  const dirs = [[1,0],[-1,0],[0,1],[0,-1]]
+  while (open.length) {
+    open.sort((a,b) => f[a]-f[b])
+    const current = open.shift()
+    openSet.delete(current)
+    if (current === goalKey) {
+      const path = []
+      let ck = current
+      while (ck) {
+        const [cx, cy] = fromKey(ck)
+        path.push({x: cx, y: cy})
+        ck = came[ck]
+      }
+      return path.reverse()
+    }
+    const [cx, cy] = fromKey(current)
+    for (const [dx,dy] of dirs) {
+      const nx = cx+dx
+      const ny = cy+dy
+      const nk = toKey(nx, ny)
+      if (nx<0 || ny<0 || nx>=cols || ny>=rows) continue
+      if (blocked.has(nk)) continue
+      const tentative = g[current] + 1
+      if (!(nk in g) || tentative < g[nk]) {
+        came[nk] = current
+        g[nk] = tentative
+        f[nk] = tentative + Math.abs(goal.x - nx) + Math.abs(goal.y - ny)
+        if (!openSet.has(nk)) { open.push(nk); openSet.add(nk) }
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- add new `pathfinder.js` implementing A-Star algorithm
- extend map2 simulation to place random target, recalc path and draw it
- recompute path whenever the map or target changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481b4bfd408331a4b050e3c4960b3a