### PR TITLE
Add Target class and random placement button

### DIFF
--- a/SimulateAsset/map.js
+++ b/SimulateAsset/map.js
@@ -1,4 +1,5 @@
 import { Obstacle } from './obstacle.js'
+import { Target } from './target.js'
 
 export class GameMap {
   constructor(cols, rows, cellSize = 40, margin = 0) {
@@ -55,6 +56,8 @@ export class GameMap {
       margin: this.margin,
       obstacles: this.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
       task: this.task
+        ? { x: this.task.x, y: this.task.y, radius: this.task.radius }
+        : null
     }
   }
 
@@ -63,7 +66,11 @@ export class GameMap {
     if (obj.obstacles) {
       gm.obstacles = obj.obstacles.map(o => new Obstacle(o.x, o.y, o.size))
     }
-    gm.task = obj.task || null
+    if (obj.task) {
+      gm.task = new Target(obj.task.x, obj.task.y, obj.task.radius)
+    } else {
+      gm.task = null
+    }
     return gm
   }
 }

--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -65,6 +65,7 @@
       <input type="checkbox" id="removeMode">
     </div>
     <button id="generateMaze">Labyrinth generieren</button>
+    <button id="randomTarget">Zufalls-Target</button>
     <div class="cone-display">Rot: <span id="redLength">0</span> px</div>
     <div class="cone-display">Grün: <span id="greenLength">0</span> px</div>
     <div class="cone-display">Blau Links 1: <span id="blueLeft1">0</span> px</div>
@@ -95,6 +96,8 @@
     import { Car } from './car.js'
     import { Obstacle } from './obstacle.js'
     import { GameMap } from './map.js'
+    import { Target } from './target.js'
+    import { aStar } from './pathfinder.js'
 
     const canvas = document.getElementById('canvas')
     const ctx = canvas.getContext('2d')
@@ -116,7 +119,8 @@
     let isDragging = false
     let dragX = 0
     let dragY = 0
-    let taskMarker = gameMap.task
+    let taskMarker = gameMap.task ? new Target(gameMap.task.x, gameMap.task.y, gameMap.task.radius) : null
+    let path = []
 
     const carImage = new Image()
     carImage.src = 'extracted_foreground.png'
@@ -157,13 +161,15 @@
         if (i !== -1) obstacles.splice(i, 1)
 
       } else if (selected === 'task') {
-        taskMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
+        taskMarker = new Target(dragX + CELL_SIZE/2, dragY + CELL_SIZE/2, Math.floor(CELL_SIZE/3))
         gameMap.task = taskMarker
+        computePath()
       } else {
         obstacles.push(new Obstacle(dragX, dragY, previewSize))
       }
 
       isDragging = false
+      computePath()
     })
 
     canvas.addEventListener('mousemove', e => {
@@ -208,9 +214,44 @@
         }
       }
       generateBorder()
+      computePath()
+    }
+
+    function placeRandomTarget() {
+      let x, y, px, py, coll
+      do {
+        x = Math.floor(Math.random() * gameMap.cols)
+        y = Math.floor(Math.random() * gameMap.rows)
+        px = x * CELL_SIZE
+        py = y * CELL_SIZE
+        coll = obstacles.some(o =>
+          px + CELL_SIZE/2 >= o.x && px + CELL_SIZE/2 <= o.x + o.size &&
+          py + CELL_SIZE/2 >= o.y && py + CELL_SIZE/2 <= o.y + o.size)
+      } while (coll)
+      taskMarker = new Target(px + CELL_SIZE/2, py + CELL_SIZE/2, Math.floor(CELL_SIZE/3))
+      gameMap.task = taskMarker
+    }
+
+    function computePath() {
+      if (!taskMarker) { path = []; return }
+      const start = {
+        x: Math.floor((car.posX + car.imgWidth/2) / CELL_SIZE),
+        y: Math.floor((car.posY + car.imgHeight/2) / CELL_SIZE)
+      }
+      const goal = {
+        x: Math.floor(taskMarker.x / CELL_SIZE),
+        y: Math.floor(taskMarker.y / CELL_SIZE)
+      }
+      const cells = aStar(start, goal, gameMap.cols, gameMap.rows, obstacles, CELL_SIZE)
+      if (cells) {
+        path = cells.map(c => ({ x: c.x * CELL_SIZE + CELL_SIZE/2, y: c.y * CELL_SIZE + CELL_SIZE/2 }))
+      } else {
+        path = []
+      }
     }
 
     generateMazeBtn.addEventListener('click', generateMaze)
+    document.getElementById('randomTarget').addEventListener('click', () => { placeRandomTarget(); computePath() })
 
     document.getElementById('saveMap').addEventListener('click', saveMap)
     document.getElementById('saveMapDb').addEventListener('click', uploadMap)
@@ -233,12 +274,26 @@
       drawGrid()
       for (const o of obstacles) o.draw(ctx)
       if (taskMarker) {
-        ctx.fillStyle='green'; ctx.beginPath(); ctx.arc(taskMarker.x, taskMarker.y, taskMarker.radius,0,Math.PI*2); ctx.fill()
+        taskMarker.draw(ctx)
+      }
+      computePath()
+      if (path.length > 1) {
+        ctx.strokeStyle = 'orange'
+        ctx.lineWidth = 3
+        ctx.beginPath()
+        ctx.moveTo(path[0].x, path[0].y)
+        for (const p of path.slice(1)) ctx.lineTo(p.x, p.y)
+        ctx.stroke()
       }
       if (isDragging && dropdown.value!=='task' && !removeCheckbox.checked) {
         ctx.strokeStyle='red'; ctx.lineWidth=2; ctx.strokeRect(dragX, dragY, previewSize, previewSize)
       }
       car.update(canvas.width, canvas.height)
+
+      if (taskMarker && taskMarker.intersectsRect(car.posX, car.posY, car.imgWidth, car.imgHeight)) {
+        placeRandomTarget()
+        computePath()
+      }
 
       redEl.textContent = Math.round(car.redConeLength)
       greenEl.textContent = Math.round(car.greenConeLength)
@@ -262,7 +317,7 @@
         rows: gameMap.rows,
         cellSize: gameMap.cellSize,
         obstacles: obstacles.map(o => ({x:o.x, y:o.y, size:o.size})),
-        task: taskMarker
+        task: taskMarker ? {x: taskMarker.x, y: taskMarker.y, radius: taskMarker.radius} : null
       }
     }
 
@@ -308,11 +363,12 @@
         gameMap = GameMap.fromJSON(obj)
         CELL_SIZE = gameMap.cellSize
         obstacles = gameMap.obstacles
-        taskMarker = gameMap.task
+        taskMarker = gameMap.task ? new Target(gameMap.task.x, gameMap.task.y, gameMap.task.radius) : null
         car.objects = obstacles
         document.getElementById('gridWidth').value = gameMap.cols
         document.getElementById('gridHeight').value = gameMap.rows
         resizeCanvas()
+        computePath()
       }
       reader.readAsText(file)
     }
@@ -341,11 +397,12 @@
           gameMap = GameMap.fromJSON(obj)
           CELL_SIZE = gameMap.cellSize
           obstacles = gameMap.obstacles
-          taskMarker = gameMap.task
+          taskMarker = gameMap.task ? new Target(gameMap.task.x, gameMap.task.y, gameMap.task.radius) : null
           car.objects = obstacles
           document.getElementById('gridWidth').value = gameMap.cols
           document.getElementById('gridHeight').value = gameMap.rows
           resizeCanvas()
+          computePath()
         })
     }
 
@@ -385,9 +442,10 @@
       car.objects = obstacles
       resizeCanvas()
       generateBorder()
+      computePath()
     }
 
-    carImage.onload = () => { resizeCanvas(); fetchAvailableMaps(); loop() }
+    carImage.onload = () => { resizeCanvas(); fetchAvailableMaps(); computePath(); loop() }
   </script>
 </body>
 </html>

--- a/SimulateAsset/pathfinder.js
+++ b/SimulateAsset/pathfinder.js
@@ -1,0 +1,54 @@
+export function aStar(start, goal, cols, rows, obstacles, cellSize) {
+  const toKey = (x, y) => `${x},${y}`
+  const fromKey = k => k.split(',').map(n => parseInt(n, 10))
+  const blocked = new Set()
+  for (const o of obstacles) {
+    const ox = o.x / cellSize
+    const oy = o.y / cellSize
+    const size = Math.ceil(o.size / cellSize)
+    for (let dx = 0; dx < size; dx++) {
+      for (let dy = 0; dy < size; dy++) {
+        blocked.add(toKey(ox + dx, oy + dy))
+      }
+    }
+  }
+  const startKey = toKey(start.x, start.y)
+  const goalKey = toKey(goal.x, goal.y)
+  const open = [startKey]
+  const openSet = new Set(open)
+  const came = {}
+  const g = { [startKey]: 0 }
+  const f = { [startKey]: Math.abs(goal.x - start.x) + Math.abs(goal.y - start.y) }
+  const dirs = [[1,0],[-1,0],[0,1],[0,-1]]
+  while (open.length) {
+    open.sort((a,b) => f[a]-f[b])
+    const current = open.shift()
+    openSet.delete(current)
+    if (current === goalKey) {
+      const path = []
+      let ck = current
+      while (ck) {
+        const [cx, cy] = fromKey(ck)
+        path.push({x: cx, y: cy})
+        ck = came[ck]
+      }
+      return path.reverse()
+    }
+    const [cx, cy] = fromKey(current)
+    for (const [dx,dy] of dirs) {
+      const nx = cx+dx
+      const ny = cy+dy
+      const nk = toKey(nx, ny)
+      if (nx<0 || ny<0 || nx>=cols || ny>=rows) continue
+      if (blocked.has(nk)) continue
+      const tentative = g[current] + 1
+      if (!(nk in g) || tentative < g[nk]) {
+        came[nk] = current
+        g[nk] = tentative
+        f[nk] = tentative + Math.abs(goal.x - nx) + Math.abs(goal.y - ny)
+        if (!openSet.has(nk)) { open.push(nk); openSet.add(nk) }
+      }
+    }
+  }
+  return null
+}

--- a/SimulateAsset/target.js
+++ b/SimulateAsset/target.js
@@ -1,0 +1,22 @@
+export class Target {
+  constructor(x, y, radius = 10) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = 'green';
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  contains(px, py) {
+    return (px - this.x) ** 2 + (py - this.y) ** 2 <= this.radius ** 2;
+  }
+
+  intersectsRect(x, y, w, h) {
+    return this.x >= x && this.x <= x + w && this.y >= y && this.y <= y + h;
+  }
+}


### PR DESCRIPTION
## Summary
- add new `target.js` to encapsulate a map target
- store target in `GameMap` using the new class
- update map editor to show and place targets correctly
- allow random target placement with a button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68481b4bfd408331a4b050e3c4960b3a