### PR TITLE
Implement Target class for map2

### DIFF
--- a/SimulateAsset/map.js
+++ b/SimulateAsset/map.js
@@ -1,4 +1,5 @@
 import { Obstacle } from './obstacle.js'
+import { Target } from './target.js'
 
 export class GameMap {
   constructor(cols, rows, cellSize = 40, margin = 0) {
@@ -54,7 +55,7 @@ export class GameMap {
       cellSize: this.cellSize,
       margin: this.margin,
       obstacles: this.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
-      task: this.task
+      task: this.task ? this.task.toJSON() : null
     }
   }
 
@@ -63,7 +64,7 @@ export class GameMap {
     if (obj.obstacles) {
       gm.obstacles = obj.obstacles.map(o => new Obstacle(o.x, o.y, o.size))
     }
-    gm.task = obj.task || null
+    gm.task = Target.fromJSON(obj.task)
     return gm
   }
 }

--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -95,6 +95,7 @@
     import { Car } from './car.js'
     import { Obstacle } from './obstacle.js'
     import { GameMap } from './map.js'
+    import { Target } from './target.js'
     import { aStar } from './pathfinder.js'
 
     const canvas = document.getElementById('canvas')
@@ -159,7 +160,7 @@
         if (i !== -1) obstacles.splice(i, 1)
 
       } else if (selected === 'task') {
-        taskMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
+        taskMarker = new Target(dragX + CELL_SIZE/2, dragY + CELL_SIZE/2, Math.floor(CELL_SIZE/3))
         gameMap.task = taskMarker
         computePath()
       } else {
@@ -226,7 +227,7 @@
           px + CELL_SIZE/2 >= o.x && px + CELL_SIZE/2 <= o.x + o.size &&
           py + CELL_SIZE/2 >= o.y && py + CELL_SIZE/2 <= o.y + o.size)
       } while (coll)
-      taskMarker = { x: px + CELL_SIZE/2, y: py + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
+      taskMarker = new Target(px + CELL_SIZE/2, py + CELL_SIZE/2, Math.floor(CELL_SIZE/3))
       gameMap.task = taskMarker
     }
 
@@ -271,10 +272,7 @@
       drawGrid()
       for (const o of obstacles) o.draw(ctx)
       if (taskMarker) {
-        ctx.fillStyle='green';
-        ctx.beginPath();
-        ctx.arc(taskMarker.x, taskMarker.y, taskMarker.radius,0,Math.PI*2);
-        ctx.fill()
+        taskMarker.draw(ctx)
       }
       computePath()
       if (path.length > 1) {
@@ -319,7 +317,7 @@
         rows: gameMap.rows,
         cellSize: gameMap.cellSize,
         obstacles: obstacles.map(o => ({x:o.x, y:o.y, size:o.size})),
-        task: taskMarker
+        task: taskMarker ? taskMarker.toJSON() : null
       }
     }
 

--- a/SimulateAsset/target.js
+++ b/SimulateAsset/target.js
@@ -1,0 +1,22 @@
+export class Target {
+  constructor(x, y, radius = 10) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = 'green';
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  toJSON() {
+    return { x: this.x, y: this.y, radius: this.radius };
+  }
+
+  static fromJSON(obj) {
+    return obj ? new Target(obj.x, obj.y, obj.radius) : null;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `Target` class to represent targets on the simulation map
- hook `GameMap` into `Target` for (de)serialization
- update `map2.html` to use the new class when placing and drawing targets

## Testing
- `node -e "import('./SimulateAsset/target.js').then(m=>console.log('ok')).catch(e=>console.error(e));"`


------
https://chatgpt.com/codex/tasks/task_e_68482203a36c833181da6d6c259ccd21