### PR TITLE
Add target placement option

### DIFF
--- a/SimulateAsset/map.js
+++ b/SimulateAsset/map.js
@@ -7,7 +7,7 @@ export class GameMap {
     this.cellSize = cellSize
     this.margin = margin
     this.obstacles = []
-    this.task = null
+    this.target = null
   }
 
   get width() { return this.cols * this.cellSize }
@@ -54,7 +54,7 @@ export class GameMap {
       cellSize: this.cellSize,
       margin: this.margin,
       obstacles: this.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
-      task: this.task
+      target: this.target
     }
   }
 
@@ -63,7 +63,7 @@ export class GameMap {
     if (obj.obstacles) {
       gm.obstacles = obj.obstacles.map(o => new Obstacle(o.x, o.y, o.size))
     }
-    gm.task = obj.task || null
+    gm.target = obj.target || null
     return gm
   }
 }

--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -57,7 +57,7 @@
         <option value="40">40x40</option>
         <option value="80">80x80</option>
         <option value="120">120x120</option>
-        <option value="task">Task (grüner Punkt)</option>
+        <option value="target">Target (grüner Punkt)</option>
       </select>
     </div>
     <div>
@@ -116,7 +116,7 @@
     let isDragging = false
     let dragX = 0
     let dragY = 0
-    let taskMarker = gameMap.task
+    let targetMarker = gameMap.target
 
     const carImage = new Image()
     carImage.src = 'extracted_foreground.png'
@@ -146,19 +146,19 @@
       const selected = dropdown.value
 
       if (removeCheckbox.checked) {
-        if (taskMarker &&
-            dragX <= taskMarker.x && dragX + CELL_SIZE >= taskMarker.x &&
-            dragY <= taskMarker.y && dragY + CELL_SIZE >= taskMarker.y) {
-          taskMarker = null
-          gameMap.task = null
-        }
+      if (targetMarker &&
+          dragX <= targetMarker.x && dragX + CELL_SIZE >= targetMarker.x &&
+          dragY <= targetMarker.y && dragY + CELL_SIZE >= targetMarker.y) {
+        targetMarker = null
+        gameMap.target = null
+      }
 
         const i = obstacles.findIndex(o => o.x === dragX && o.y === dragY)
         if (i !== -1) obstacles.splice(i, 1)
 
-      } else if (selected === 'task') {
-        taskMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
-        gameMap.task = taskMarker
+      } else if (selected === 'target') {
+        targetMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) }
+        gameMap.target = targetMarker
       } else {
         obstacles.push(new Obstacle(dragX, dragY, previewSize))
       }
@@ -232,10 +232,10 @@
       ctx.clearRect(0,0,canvas.width,canvas.height)
       drawGrid()
       for (const o of obstacles) o.draw(ctx)
-      if (taskMarker) {
-        ctx.fillStyle='green'; ctx.beginPath(); ctx.arc(taskMarker.x, taskMarker.y, taskMarker.radius,0,Math.PI*2); ctx.fill()
+      if (targetMarker) {
+        ctx.fillStyle='green'; ctx.beginPath(); ctx.arc(targetMarker.x, targetMarker.y, targetMarker.radius,0,Math.PI*2); ctx.fill()
       }
-      if (isDragging && dropdown.value!=='task' && !removeCheckbox.checked) {
+      if (isDragging && dropdown.value!=='target' && !removeCheckbox.checked) {
         ctx.strokeStyle='red'; ctx.lineWidth=2; ctx.strokeRect(dragX, dragY, previewSize, previewSize)
       }
       car.update(canvas.width, canvas.height)
@@ -262,7 +262,7 @@
         rows: gameMap.rows,
         cellSize: gameMap.cellSize,
         obstacles: obstacles.map(o => ({x:o.x, y:o.y, size:o.size})),
-        task: taskMarker
+        target: targetMarker
       }
     }
 
@@ -308,7 +308,7 @@
         gameMap = GameMap.fromJSON(obj)
         CELL_SIZE = gameMap.cellSize
         obstacles = gameMap.obstacles
-        taskMarker = gameMap.task
+        targetMarker = gameMap.target
         car.objects = obstacles
         document.getElementById('gridWidth').value = gameMap.cols
         document.getElementById('gridHeight').value = gameMap.rows
@@ -341,7 +341,7 @@
           gameMap = GameMap.fromJSON(obj)
           CELL_SIZE = gameMap.cellSize
           obstacles = gameMap.obstacles
-          taskMarker = gameMap.task
+          targetMarker = gameMap.target
           car.objects = obstacles
           document.getElementById('gridWidth').value = gameMap.cols
           document.getElementById('gridHeight').value = gameMap.rows
@@ -381,7 +381,7 @@
       if (isNaN(w) || isNaN(h) || w <= 0 || h <= 0) { alert('Invalid size'); return }
       gameMap = new GameMap(w, h, CELL_SIZE)
       obstacles = gameMap.obstacles
-      taskMarker = null
+      targetMarker = null
       car.objects = obstacles
       resizeCanvas()
       generateBorder()


### PR DESCRIPTION
## Summary
- allow placing a `Target` point in Simulated Asset map
- rename map attribute from `task` to `target`

## Testing
- `node --check SimulateAsset/map.js`
- `node --check SimulateAsset/car.js`

------
https://chatgpt.com/codex/tasks/task_e_684825e4fd6c8331a9ce570dfb7cca1d