### PR TITLE
Add Target class for map placement

### DIFF
--- a/SimulateAsset/Target.js
+++ b/SimulateAsset/Target.js
@@ -1,0 +1,14 @@
+export class Target {
+  constructor(x, y, radius) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = 'green';
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}

--- a/SimulateAsset/db.js
+++ b/SimulateAsset/db.js
@@ -5,6 +5,8 @@ export function getCurrentMapData(gameMap) {
     cellSize: gameMap.cellSize,
     obstacles: gameMap.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
     target: gameMap.target
+      ? { x: gameMap.target.x, y: gameMap.target.y, radius: gameMap.target.radius }
+      : null
   };
 }
 

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -1,6 +1,7 @@
 import { Car } from './car.js';
 import { GameMap } from './map.js';
 import { Obstacle } from './obstacle.js';
+import { Target } from './Target.js';
 import { generateMaze, generateBorder } from './mapGenerator.js';
 import * as db from './db.js';
 
@@ -65,7 +66,11 @@ canvas.addEventListener('mouseup', () => {
     if (i !== -1) obstacles.splice(i, 1);
 
   } else if (selected === 'target') {
-    targetMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) };
+    targetMarker = new Target(
+      dragX + CELL_SIZE / 2,
+      dragY + CELL_SIZE / 2,
+      Math.floor(CELL_SIZE / 3)
+    );
     gameMap.target = targetMarker;
   } else {
     obstacles.push(new Obstacle(dragX, dragY, previewSize));
@@ -102,10 +107,7 @@ function loop() {
   drawGrid();
   for (const o of obstacles) o.draw(ctx);
   if (targetMarker) {
-    ctx.fillStyle='green';
-    ctx.beginPath();
-    ctx.arc(targetMarker.x, targetMarker.y, targetMarker.radius,0,Math.PI*2);
-    ctx.fill();
+    targetMarker.draw(ctx);
   }
   if (isDragging && dropdown.value!=='target' && !removeCheckbox.checked) {
     ctx.strokeStyle='red';

--- a/SimulateAsset/map.js
+++ b/SimulateAsset/map.js
@@ -1,4 +1,5 @@
 import { Obstacle } from './obstacle.js'
+import { Target } from './Target.js'
 
 export class GameMap {
   constructor(cols, rows, cellSize = 40, margin = 0) {
@@ -55,6 +56,8 @@ export class GameMap {
       margin: this.margin,
       obstacles: this.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
       target: this.target
+        ? { x: this.target.x, y: this.target.y, radius: this.target.radius }
+        : null
     }
   }
 
@@ -63,7 +66,9 @@ export class GameMap {
     if (obj.obstacles) {
       gm.obstacles = obj.obstacles.map(o => new Obstacle(o.x, o.y, o.size))
     }
-    gm.target = obj.target || null
+    gm.target = obj.target
+      ? new Target(obj.target.x, obj.target.y, obj.target.radius)
+      : null
     return gm
   }
 }


### PR DESCRIPTION
## Summary
- add `Target` class to represent target points
- integrate `Target` with map serialization and main loop
- adjust database helper to save target coordinates

## Testing
- `node --check SimulateAsset/Target.js`
- `node --check SimulateAsset/map.js`
- `node --check SimulateAsset/main.js`
- `node --check SimulateAsset/db.js`


------
https://chatgpt.com/codex/tasks/task_e_6848377b1b7c833180329705fffb3cab