### PR TITLE
Add Target class for map placement

### DIFF
--- a/SimulateAsset/Target.js
+++ b/SimulateAsset/Target.js
@@ -1,0 +1,14 @@
+export class Target {
+  constructor(x, y, radius) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = 'green';
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}

--- a/SimulateAsset/db.js
+++ b/SimulateAsset/db.js
@@ -5,6 +5,8 @@ export function getCurrentMapData(gameMap) {
     cellSize: gameMap.cellSize,
     obstacles: gameMap.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
     target: gameMap.target
+      ? { x: gameMap.target.x, y: gameMap.target.y, radius: gameMap.target.radius }
+      : null
   };
 }
 

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -1,12 +1,16 @@
 import { Car } from './car.js';
 import { GameMap } from './map.js';
 import { Obstacle } from './obstacle.js';
+import { Target } from './Target.js';
 import { generateMaze, generateBorder } from './mapGenerator.js';
 import * as db from './db.js';
 
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
-const dropdown = document.getElementById('obstacleSize');
+// Dropdown for choosing obstacle size
+const sizeDropdown = document.getElementById('obstacleSize');
+// Dedicated dropdown to toggle target placement mode
+const targetDropdown = document.getElementById('targetMode');
 const removeCheckbox = document.getElementById('removeMode');
 const generateMazeBtn = document.getElementById('generateMaze');
 const redEl = document.getElementById('redLength');
@@ -20,7 +24,7 @@ const blueBackEl = document.getElementById('blueBack');
 let gameMap = new GameMap(20, 15);
 let CELL_SIZE = gameMap.cellSize;
 let obstacles = gameMap.obstacles;
-let previewSize = parseInt(dropdown.value);
+let previewSize = parseInt(sizeDropdown.value);
 let isDragging = false;
 let dragX = 0;
 let dragY = 0;
@@ -37,8 +41,8 @@ function resizeCanvas() {
 
 window.addEventListener('resize', resizeCanvas);
 
-dropdown.addEventListener('change', () => {
-  const val = dropdown.value;
+sizeDropdown.addEventListener('change', () => {
+  const val = sizeDropdown.value;
   previewSize = parseInt(val) || CELL_SIZE;
 });
 
@@ -51,7 +55,6 @@ canvas.addEventListener('mousedown', e => {
 
 canvas.addEventListener('mouseup', () => {
   if (!isDragging) return;
-  const selected = dropdown.value;
 
   if (removeCheckbox.checked) {
     if (targetMarker &&
@@ -64,8 +67,12 @@ canvas.addEventListener('mouseup', () => {
     const i = obstacles.findIndex(o => o.x === dragX && o.y === dragY);
     if (i !== -1) obstacles.splice(i, 1);
 
-  } else if (selected === 'target') {
-    targetMarker = { x: dragX + CELL_SIZE/2, y: dragY + CELL_SIZE/2, radius: Math.floor(CELL_SIZE/3) };
+  } else if (targetDropdown.value === 'target') {
+    targetMarker = new Target(
+      dragX + CELL_SIZE / 2,
+      dragY + CELL_SIZE / 2,
+      Math.floor(CELL_SIZE / 3)
+    );
     gameMap.target = targetMarker;
   } else {
     obstacles.push(new Obstacle(dragX, dragY, previewSize));
@@ -102,12 +109,9 @@ function loop() {
   drawGrid();
   for (const o of obstacles) o.draw(ctx);
   if (targetMarker) {
-    ctx.fillStyle='green';
-    ctx.beginPath();
-    ctx.arc(targetMarker.x, targetMarker.y, targetMarker.radius,0,Math.PI*2);
-    ctx.fill();
+    targetMarker.draw(ctx);
   }
-  if (isDragging && dropdown.value!=='target' && !removeCheckbox.checked) {
+  if (isDragging && targetDropdown.value!=='target' && !removeCheckbox.checked) {
     ctx.strokeStyle='red';
     ctx.lineWidth=2;
     ctx.strokeRect(dragX, dragY, previewSize, previewSize);

--- a/SimulateAsset/map.js
+++ b/SimulateAsset/map.js
@@ -1,4 +1,5 @@
 import { Obstacle } from './obstacle.js'
+import { Target } from './Target.js'
 
 export class GameMap {
   constructor(cols, rows, cellSize = 40, margin = 0) {
@@ -55,6 +56,8 @@ export class GameMap {
       margin: this.margin,
       obstacles: this.obstacles.map(o => ({ x: o.x, y: o.y, size: o.size })),
       target: this.target
+        ? { x: this.target.x, y: this.target.y, radius: this.target.radius }
+        : null
     }
   }
 
@@ -63,7 +66,9 @@ export class GameMap {
     if (obj.obstacles) {
       gm.obstacles = obj.obstacles.map(o => new Obstacle(o.x, o.y, o.size))
     }
-    gm.target = obj.target || null
+    gm.target = obj.target
+      ? new Target(obj.target.x, obj.target.y, obj.target.radius)
+      : null
     return gm
   }
 }

--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -57,6 +57,12 @@
         <option value="40">40x40</option>
         <option value="80">80x80</option>
         <option value="120">120x120</option>
+      </select>
+    </div>
+    <div>
+      <label>Target:</label>
+      <select id="targetMode">
+        <option value="none">--</option>
         <option value="target">Target (grüner Punkt)</option>
       </select>
     </div>


### PR DESCRIPTION
## Summary
- add `Target` class to represent target points
- integrate `Target` with map serialization and main loop
- add dedicated dropdown to place target markers
- clarify obstacle size dropdown variable name

## Testing
- `node --check SimulateAsset/Target.js`
- `node --check SimulateAsset/main.js`
- `node --check SimulateAsset/map.js`
- `node --check SimulateAsset/db.js`


------
https://chatgpt.com/codex/tasks/task_e_6848377b1b7c833180329705fffb3cab