### PR TITLE
Implement green target placement

### DIFF
--- a/Environment/GridMap.java
+++ b/Environment/GridMap.java
@@ -2,6 +2,7 @@ package Environment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class GridMap {
     public int width;
@@ -10,6 +11,7 @@ public class GridMap {
     public List<Asset> assets;
     public List<Coord> obstacles;
     public List<Coord> targets;
+    private final Random rand = new Random();
 
     public GridMap(int width, int height) {
         this.width = width;
@@ -40,6 +42,22 @@ public class GridMap {
             targets.add(c);
             gridArray[c.y][c.x] = 2;
         }
+    }
+
+    /**
+     * Place a target at a random free coordinate on the map.
+     * @return the coordinate of the placed target or null if no free spot was found
+     */
+    public Coord placeRandomTarget() {
+        int attempts = width * height * 2;
+        while (attempts-- > 0) {
+            Coord c = new Coord(rand.nextInt(width), rand.nextInt(height));
+            if (isFree(c)) {
+                addTarget(c);
+                return c;
+            }
+        }
+        return null;
     }
 
     public void addAsset(Asset asset, Coord c) {

--- a/Environment/Simulation.java
+++ b/Environment/Simulation.java
@@ -10,10 +10,12 @@ public class Simulation {
         map.addAsset(robot, new Coord(2, 2));
 
         map.addObstacle(new Coord(5, 5));
-        map.addTarget(new Coord(7, 7));
+        Coord target = map.placeRandomTarget();
 
         Task task = new Task("T1", 1);
-        task.coordinates.addAll(Arrays.asList(new Coord(7, 7)));
+        if (target != null) {
+            task.coordinates.addAll(Arrays.asList(target));
+        }
         robot.task = task;
         task.assignedAssets.add(robot);
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ These classes form a starting point for building a more complete simulation in J
 
 ## Frontend Prototype
 
-The `frontend` folder contains a small HTML/JS interface that visualizes the `GridMap` structure. The UI lets you mark obstacles, targets and walkable cells, place assets and assign simple tasks. A toggle is provided to switch between the full map and a POV style view around a selected asset.
+The `frontend` folder contains a small HTML/JS interface that visualizes the
+`GridMap` structure. The UI lets you mark obstacles, targets and walkable cells,
+place assets and assign simple tasks. Choose **Target** from the mode dropdown
+and click on the map to drop green markers.
 
-Open `frontend/index.html` in a browser to try it out. No backend connectivity is required.
+Open `frontend/map/index.html` in a browser to try it out. No backend connectivity is required.
 
 ## Backend
 

--- a/frontend/map/style.css
+++ b/frontend/map/style.css
@@ -47,7 +47,10 @@ body {
 }
 
 .cell.obstacle { background: #444; }
-.cell.target { background: #fffa65; }
+.cell.target {
+  background: #2ecc40;
+  border-radius: 50%;
+}
 .cell.asset { background: #4CAF50; color: white; }
 .cell.path { background: #5bc0de; }
 .cell.selected { outline: 2px solid red; }


### PR DESCRIPTION
## Summary
- maintain a `Random` instance in `GridMap`
- update `placeRandomTarget` to reuse the field
- style targets as green dots
- clarify frontend instructions in README

## Testing
- `javac Environment/*.java`
- `java -cp . Environment.Simulation`


------
https://chatgpt.com/codex/tasks/task_e_68483f2cbd64833180bd41c5d4cc9c1e