### PR TITLE
Add target marker functionality

### DIFF
--- a/frontend/map/app.js
+++ b/frontend/map/app.js
@@ -118,6 +118,11 @@ function renderGrid() {
   for (const cell of view) {
     const div = document.createElement('div');
     div.className = 'cell ' + cell.type;
+    div.innerHTML = '';
+    if (cell.type === 'target') {
+      const tgt = new Target(cell.x, cell.y);
+      tgt.attach(div);
+    }
     if (cell.assetId) div.classList.add('asset');
     if (state.path.some(p => p.x === cell.x && p.y === cell.y)) {
       div.classList.add('path');
@@ -130,7 +135,9 @@ function renderGrid() {
     div.addEventListener('click', onCellClick);
     if (cell.assetId) {
       const asset = state.assets.find(a => a.id === cell.assetId);
-      div.textContent = cell.assetId;
+      const span = document.createElement('span');
+      span.textContent = cell.assetId;
+      div.appendChild(span);
       div.title = `${asset.id}\nBattery: ${asset.battery}%` +
         (asset.taskId ? `\nTask: ${asset.taskId}` : '');
     }
@@ -231,6 +238,11 @@ function applyDraw(cellEl) {
 
   const cell = state.map.cells[y][x];
   cellEl.className = 'cell ' + cell.type;
+  cellEl.innerHTML = '';
+  if (cell.type === 'target') {
+    const tgt = new Target(x, y);
+    tgt.attach(cellEl);
+  }
   if (cell.assetId) cellEl.classList.add('asset');
   if (state.path.some(p => p.x === x && p.y === y)) {
     cellEl.classList.add('path');
@@ -240,11 +252,15 @@ function applyDraw(cellEl) {
   }
   if (cell.assetId) {
     const asset = state.assets.find(a => a.id === cell.assetId);
-    cellEl.textContent = cell.assetId;
+    const span = document.createElement('span');
+    span.textContent = cell.assetId;
+    cellEl.appendChild(span);
     cellEl.title = `${asset.id}\nBattery: ${asset.battery}%` +
       (asset.taskId ? `\nTask: ${asset.taskId}` : '');
   } else {
-    cellEl.textContent = '';
+    if (cell.type !== 'target') {
+      cellEl.textContent = '';
+    }
     cellEl.removeAttribute('title');
   }
 }

--- a/frontend/map/index.html
+++ b/frontend/map/index.html
@@ -51,6 +51,7 @@
       </div>
     </div>
   </div>
+  <script src="target.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/map/style.css
+++ b/frontend/map/style.css
@@ -47,7 +47,21 @@ body {
 }
 
 .cell.obstacle { background: #444; }
-.cell.target { background: #fffa65; }
+.cell.target {
+  background: #fff;
+  position: relative;
+}
+.target-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  margin-top: -6px;
+  border-radius: 50%;
+  background: green;
+}
 .cell.asset { background: #4CAF50; color: white; }
 .cell.path { background: #5bc0de; }
 .cell.selected { outline: 2px solid red; }

--- a/frontend/map/target.js
+++ b/frontend/map/target.js
@@ -1,0 +1,17 @@
+class Target {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  attach(cellEl) {
+    if (!cellEl) return;
+    if (!cellEl.querySelector('.target-dot')) {
+      const dot = document.createElement('div');
+      dot.className = 'target-dot';
+      cellEl.appendChild(dot);
+    }
+  }
+}
+
+window.Target = Target;


### PR DESCRIPTION
## Summary
- add `Target` class for UI markers
- display target cells as green dots
- keep target markers when drawing or rendering

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684842df4ecc833197f9bd51eec62ecd