### PR TITLE
Fix canvas clearing order

### DIFF
--- a/SimulateAsset/car.js
+++ b/SimulateAsset/car.js
@@ -105,7 +105,6 @@ export class Car {
   }
 
   draw(canvasWidth, canvasHeight) {
-    this.ctx.clearRect(0, 0, canvasWidth, canvasHeight);
     this.drawBorder(canvasWidth, canvasHeight);
 
     this.ctx.save();


### PR DESCRIPTION
## Summary
- let `main.js` clear the canvas each frame
- stop clearing from `Car.draw`

## Testing
- `node --check SimulateAsset/car.js`
- `node --check SimulateAsset/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68484e15cee083319fbc51fc751c2f10