### PR TITLE
Add vehicle metrics display

### DIFF
--- a/SimulateAsset/car.js
+++ b/SimulateAsset/car.js
@@ -24,6 +24,11 @@ export class Car {
     this.rotAccelRate = 0.0005;
     this.rotDecelRate = 0.003;
 
+    this.maxRpm = 5000;
+    this.speed = 0;
+    this.rpm = 0;
+    this.gyro = 0;
+
     this.keys = {
       ArrowUp: false,
       ArrowDown: false,
@@ -179,6 +184,10 @@ export class Car {
     } else {
       this.velocity = this.acceleration = this.angularVelocity = this.angularAcceleration = 0;
     }
+
+    this.speed = Math.abs(this.velocity * 60);
+    this.rpm = Math.abs(this.velocity / this.maxSpeed * this.maxRpm);
+    this.gyro = ((this.rotation * 180 / Math.PI) % 360 + 360) % 360;
 
     this.draw(canvasWidth, canvasHeight);
   }

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -17,6 +17,9 @@ const blueLeft2El = document.getElementById('blueLeft2');
 const blueRight1El = document.getElementById('blueRight1');
 const blueRight2El = document.getElementById('blueRight2');
 const blueBackEl = document.getElementById('blueBack');
+const speedEl = document.getElementById('speed');
+const rpmEl = document.getElementById('rpm');
+const gyroEl = document.getElementById('gyro');
 
 let gameMap = new GameMap(20, 15);
 let CELL_SIZE = gameMap.cellSize;
@@ -137,6 +140,9 @@ function loop() {
   blueRight1El.textContent = Math.round(br1);
   blueRight2El.textContent = Math.round(br2);
   blueBackEl.textContent = Math.round(bb);
+  speedEl.textContent = Math.round(car.speed);
+  rpmEl.textContent = Math.round(car.rpm);
+  gyroEl.textContent = car.gyro.toFixed(1);
 
   requestAnimationFrame(loop);
 }

--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -72,6 +72,9 @@
     <div class="cone-display">Blau Rechts 1: <span id="blueRight1">0</span> px</div>
     <div class="cone-display">Blau Rechts 2: <span id="blueRight2">0</span> px</div>
     <div class="cone-display">Blau Hinten: <span id="blueBack">0</span> px</div>
+    <div class="cone-display">Geschwindigkeit: <span id="speed">0</span> px/s</div>
+    <div class="cone-display">Drehzahl: <span id="rpm">0</span> RPM</div>
+    <div class="cone-display">Gyro: <span id="gyro">0</span>°</div>
     <label>Size:
       <input id="gridWidth" type="number" value="20" min="1" style="width:60px"> x
       <input id="gridHeight" type="number" value="15" min="1" style="width:60px">


### PR DESCRIPTION
## Summary
- extend car simulation with speed, RPM and gyro data
- show new metrics in `map2.html`
- update main loop to render these values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485584905c8331a89549ab0e567dfb