### PR TITLE
Check target overlap when creating obstacles

### DIFF
--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -185,7 +185,10 @@ function loadMapFile(e) {
   });
 }
 
-generateMazeBtn.addEventListener('click', () => generateMaze(gameMap));
+generateMazeBtn.addEventListener('click', () => {
+  generateMaze(gameMap, respawnTarget);
+  refreshCarObjects();
+});
 
 document.getElementById('saveMap').addEventListener('click', () => db.downloadMap(gameMap));
 
@@ -260,9 +263,9 @@ document.getElementById('setSizeBtn').addEventListener('click', () => {
   gameMap = new GameMap(w, h, CELL_SIZE);
   obstacles = gameMap.obstacles;
   targetMarker = null;
-  refreshCarObjects();
   resizeCanvas();
-  generateBorder(gameMap);
+  generateBorder(gameMap, respawnTarget);
+  refreshCarObjects();
 });
 
 carImage.onload = () => { resizeCanvas(); document.getElementById('fetchMaps').click(); loop(); };

--- a/SimulateAsset/mapGenerator.js
+++ b/SimulateAsset/mapGenerator.js
@@ -1,36 +1,62 @@
 import { Obstacle } from './Obstacle.js';
 
-export function generateBorder(gameMap) {
-  const { cols, rows, cellSize, obstacles } = gameMap;
+export function generateBorder(gameMap, respawnTarget) {
+  const { cols, rows, cellSize, obstacles, target } = gameMap;
   for (let x = 0; x < cols; x++) {
     for (const y of [0, rows - 1]) {
-      obstacles.push(new Obstacle(x * cellSize, y * cellSize, cellSize));
+      const ox = x * cellSize;
+      const oy = y * cellSize;
+      if (target && target.intersectsRect(ox, oy, cellSize, cellSize)) {
+        if (typeof respawnTarget === 'function') respawnTarget();
+        else continue;
+      }
+      obstacles.push(new Obstacle(ox, oy, cellSize));
     }
   }
   for (let y = 1; y < rows - 1; y++) {
     for (const x of [0, cols - 1]) {
-      obstacles.push(new Obstacle(x * cellSize, y * cellSize, cellSize));
+      const ox = x * cellSize;
+      const oy = y * cellSize;
+      if (target && target.intersectsRect(ox, oy, cellSize, cellSize)) {
+        if (typeof respawnTarget === 'function') respawnTarget();
+        else continue;
+      }
+      obstacles.push(new Obstacle(ox, oy, cellSize));
     }
   }
 }
 
-export function generateMaze(gameMap) {
-  const { cols, rows, cellSize, obstacles } = gameMap;
+export function generateMaze(gameMap, respawnTarget) {
+  const { cols, rows, cellSize, obstacles, target } = gameMap;
   obstacles.length = 0;
   const minPassage = 4, maxPassage = 6;
   let y = 1;
   while (y < rows - 1) {
     const h = Math.floor(Math.random() * (maxPassage - minPassage + 1)) + minPassage;
-    for (let x = 1; x < cols - 1; x++) if (Math.random() < 0.3)
-      obstacles.push(new Obstacle(x * cellSize, y * cellSize, cellSize));
+    for (let x = 1; x < cols - 1; x++) if (Math.random() < 0.3) {
+      const ox = x * cellSize;
+      const oy = y * cellSize;
+      if (target && target.intersectsRect(ox, oy, cellSize, cellSize)) {
+        if (typeof respawnTarget === 'function') respawnTarget();
+        else continue;
+      }
+      obstacles.push(new Obstacle(ox, oy, cellSize));
+    }
     y += h;
     if (y < rows - 1) {
       const gapStart = Math.floor(Math.random() * (cols - 10)) + 5;
       const gapWidth = Math.floor(Math.random() * 3) + 4;
-      for (let x = 1; x < cols - 1; x++) if (x < gapStart || x > gapStart + gapWidth)
-        obstacles.push(new Obstacle(x * cellSize, y * cellSize, cellSize));
+      for (let x = 1; x < cols - 1; x++) if (x < gapStart || x > gapStart + gapWidth) {
+        const ox = x * cellSize;
+        const oy = y * cellSize;
+        if (target && target.intersectsRect(ox, oy, cellSize, cellSize)) {
+          if (typeof respawnTarget === 'function') respawnTarget();
+          else continue;
+        }
+        obstacles.push(new Obstacle(ox, oy, cellSize));
+      }
       y++;
     }
   }
-  generateBorder(gameMap);
+  generateBorder(gameMap, respawnTarget);
 }


### PR DESCRIPTION
## Summary
- avoid placing new obstacles where the target already is
- allow relocate via `respawnTarget`
- hook up new function parameters in main.js
- refresh car obstacles after maze/border generation

## Testing
- `node -c SimulateAsset/mapGenerator.js`
- `node -c SimulateAsset/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68485a25ac648331b296ea8111c13b83