### PR TITLE
Move car API to SimulateAsset

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 psycopg2-binary
+Flask-Cors

--- a/README.md
+++ b/README.md
@@ -68,3 +68,22 @@ Available routes:
 - `GET /api/assets/<id>` – fetch one asset
 - `PUT /api/assets/<id>` – update fields of an asset
 - `DELETE /api/assets/<id>` – remove an asset
+
+## Flask Car Data API
+
+`SimulateAsset/car_api.py` exposes simulated car telemetry and streams a demo video.
+Start the server with:
+
+```bash
+python SimulateAsset/car_api.py
+```
+
+The API provides two endpoints:
+
+- `GET /api/car` – return current speed, RPM, gyroscope value and dummy distance sensor values.
+- `GET /api/video` – stream the file `dummy-video.mp4` located in `SimulateAsset`. You need to supply this file yourself as it is not included in the repository.
+
+## Transmitter Demo Page
+
+A small HTML file `Transmitter/car_dashboard.html` shows how to read the API and display the demo video.
+Open the file in a browser after starting the Flask server to see live values and the stream.

--- a/SimulateAsset/car_api.py
+++ b/SimulateAsset/car_api.py
@@ -1,0 +1,50 @@
+from flask import Flask, jsonify, send_from_directory
+from flask_cors import CORS
+import os
+import random
+
+app = Flask(__name__)
+CORS(app)
+
+class Car:
+    def __init__(self):
+        self.speed = 0.0
+        self.rpm = 0
+        self.gyro = 0.0
+        self.distances = {
+            'front': 0,
+            'rear': 0,
+            'left': 0,
+            'right': 0
+        }
+
+    def update(self):
+        """Fill the fields with some random demo values."""
+        self.speed = round(random.uniform(0, 30), 2)
+        self.rpm = int(self.speed * 100)
+        self.gyro = round(random.uniform(0, 360), 1)
+        self.distances = {k: int(random.uniform(0, 150)) for k in self.distances}
+
+car = Car()
+
+@app.route('/api/car', methods=['GET'])
+def get_car_data():
+    car.update()
+    return jsonify({
+        'speed': car.speed,
+        'rpm': car.rpm,
+        'gyro': car.gyro,
+        'distances': car.distances
+    })
+
+@app.route('/api/video', methods=['GET'])
+def get_video():
+    """Stream dummy-video.mp4 if present."""
+    directory = os.path.dirname(__file__)
+    video_file = os.path.join(directory, 'dummy-video.mp4')
+    if not os.path.isfile(video_file):
+        return jsonify({'error': 'dummy-video.mp4 missing'}), 404
+    return send_from_directory(directory, 'dummy-video.mp4', mimetype='video/mp4')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5001, debug=True)

--- a/Transmitter/car_dashboard.html
+++ b/Transmitter/car_dashboard.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Car Telemetry</title>
+    <style>
+        body { font-family: Arial, sans-serif; background: #111; color: #eee; padding: 20px; }
+        #data { margin-bottom: 20px; }
+        video { max-width: 100%; height: auto; }
+    </style>
+</head>
+<body>
+    <h1>Car Telemetry Dashboard</h1>
+    <div id="data">
+        <p>Speed: <span id="speed">-</span> km/h</p>
+        <p>RPM: <span id="rpm">-</span></p>
+        <p>Gyro: <span id="gyro">-</span>°</p>
+        <p>Distances: <span id="distances">-</span></p>
+    </div>
+    <video id="video" controls src="http://localhost:5001/api/video"></video>
+
+    <script>
+        async function fetchData() {
+            try {
+                const res = await fetch('http://localhost:5001/api/car');
+                if (!res.ok) return;
+                const data = await res.json();
+                document.getElementById('speed').textContent = data.speed;
+                document.getElementById('rpm').textContent = data.rpm;
+                document.getElementById('gyro').textContent = data.gyro;
+                document.getElementById('distances').textContent = JSON.stringify(data.distances);
+            } catch (e) {
+                console.error(e);
+            }
+        }
+        setInterval(fetchData, 1000);
+        fetchData();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- place car_api.py under `SimulateAsset`
- add simple dashboard in `Transmitter`
- document how to run the API and view the demo page

## Testing
- `python -m py_compile SimulateAsset/car_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68485a99a9f083319d028f203bdd546c