### PR TITLE
Enhance car API with POST updates

### DIFF
--- a/Backend/car_api.py
+++ b/Backend/car_api.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, send_from_directory
+from flask import Flask, jsonify, send_from_directory, request
 from flask_cors import CORS
 import os
 import random
@@ -18,24 +18,49 @@ class Car:
             'right': 0
         }
 
-    def update(self):
+    def update_random(self):
         """Fill the fields with some random demo values."""
         self.speed = round(random.uniform(0, 30), 2)
         self.rpm = int(self.speed * 100)
         self.gyro = round(random.uniform(0, 360), 1)
         self.distances = {k: int(random.uniform(0, 150)) for k in self.distances}
 
+    def update_from_dict(self, data):
+        """Assign data from a dictionary to the car state."""
+        self.speed = float(data.get('speed', self.speed))
+        self.rpm = int(data.get('rpm', self.rpm))
+        self.gyro = float(data.get('gyro', self.gyro))
+        distances = data.get('distances', {})
+        for k in self.distances.keys():
+            if k in distances:
+                self.distances[k] = int(distances[k])
+
 car = Car()
 
 @app.route('/api/car', methods=['GET'])
 def get_car_data():
-    car.update()
     return jsonify({
         'speed': car.speed,
         'rpm': car.rpm,
         'gyro': car.gyro,
         'distances': car.distances
     })
+
+
+@app.route('/api/car', methods=['POST'])
+def set_car_data():
+    data = request.get_json() or {}
+    required = ['speed', 'rpm', 'gyro', 'distances']
+    if not all(k in data for k in required):
+        return jsonify({'error': 'invalid payload'}), 400
+    distances = data['distances']
+    if not isinstance(distances, dict) or not all(k in distances for k in ['front', 'rear', 'left', 'right']):
+        return jsonify({'error': 'invalid payload'}), 400
+    try:
+        car.update_from_dict(data)
+    except (TypeError, ValueError):
+        return jsonify({'error': 'invalid payload'}), 400
+    return jsonify({'status': 'ok'})
 
 @app.route('/api/video', methods=['GET'])
 def get_video():


### PR DESCRIPTION
## Summary
- keep `update_random` for demo purposes
- add `update_from_dict` method to update the stored car values
- expose `POST /api/car` for writing data
- stop generating random data on `GET /api/car`

## Testing
- `python -m py_compile Backend/car_api.py`

------
https://chatgpt.com/codex/tasks/task_e_684862d357488331a9c3a887a98f575e