### PR TITLE
Add GET endpoint to simulation API

### DIFF
--- a/Backend/car_api.py
+++ b/Backend/car_api.py
@@ -18,6 +18,22 @@ class Car:
             'right': 0
         }
 
+    def control(self, action):
+        """Very small state change based on a simple action."""
+        if action == 'up':
+            self.speed = min(self.speed + 1, 30)
+            self.rpm = int(self.speed * 100)
+        elif action == 'down':
+            self.speed = max(self.speed - 1, 0)
+            self.rpm = int(self.speed * 100)
+        elif action == 'left':
+            self.gyro = (self.gyro - 5) % 360
+        elif action == 'right':
+            self.gyro = (self.gyro + 5) % 360
+        elif action == 'stop':
+            self.speed = 0
+            self.rpm = 0
+
     def update_random(self):
         """Fill the fields with some random demo values."""
         self.speed = round(random.uniform(0, 30), 2)
@@ -60,6 +76,16 @@ def set_car_data():
         car.update_from_dict(data)
     except (TypeError, ValueError):
         return jsonify({'error': 'invalid payload'}), 400
+    return jsonify({'status': 'ok'})
+
+
+@app.route('/api/control', methods=['POST'])
+def control_car():
+    data = request.get_json() or {}
+    action = data.get('action')
+    if action not in ['up', 'down', 'left', 'right', 'stop']:
+        return jsonify({'error': 'invalid action'}), 400
+    car.control(action)
     return jsonify({'status': 'ok'})
 
 @app.route('/api/video', methods=['GET'])

--- a/Backend/control_api.py
+++ b/Backend/control_api.py
@@ -1,0 +1,41 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+class CarController:
+    """Placeholder controller that would talk to the real vehicle."""
+    def __init__(self):
+        self.last_action = None
+
+    def execute(self, action: str):
+        # Integration with actual car hardware would happen here.
+        self.last_action = action
+
+controller = CarController()
+
+VALID_ACTIONS = {
+    'forward': 'forward',
+    'backward': 'backward',
+    'left': 'left',
+    'right': 'right',
+    'stop': 'stop',
+    # allow arrow style synonyms
+    'up': 'forward',
+    'down': 'backward',
+}
+
+@app.route('/api/control', methods=['POST'])
+def control_car():
+    data = request.get_json() or {}
+    raw_action = data.get('action')
+    action = VALID_ACTIONS.get(raw_action)
+    if action is None:
+        return jsonify({'error': 'invalid action'}), 400
+    controller.execute(action)
+    return jsonify({'status': 'ok', 'action': controller.last_action})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5002, debug=True)
+

--- a/README.md
+++ b/README.md
@@ -113,3 +113,26 @@ values, e.g.:
 The JavaScript simulation posts its calculated data to `/api/car` so that
 `Transmitter/car_dashboard.html` can show the live telemetry values.
 
+
+## Car Control API
+
+A separate Flask service is provided in `Backend/control_api.py` for sending
+movement commands to the vehicle. Start it with:
+
+```bash
+python Backend/control_api.py
+```
+
+It runs on port `5002` and accepts POST requests to `/api/control` with an
+`action` field:
+
+```bash
+curl -X POST http://localhost:5002/api/control \
+     -H "Content-Type: application/json" \
+     -d '{"action": "forward"}'
+```
+
+Valid actions are `forward`, `backward`, `left`, `right` and `stop` (the values
+`up` and `down` are accepted as synonyms for `forward` and `backward`). The
+implementation simply records the last action; integration with actual hardware
+can be added where indicated in the code.

--- a/SimulateAsset/car_api.py
+++ b/SimulateAsset/car_api.py
@@ -29,6 +29,17 @@ class Car:
 
 car = Car()
 
+@app.route('/api/car', methods=['GET'])
+def get_car_data():
+    """Return the current car telemetry."""
+    return jsonify({
+        'speed': car.speed,
+        'rpm': car.rpm,
+        'gyro': car.gyro,
+        'distances': car.distances
+    })
+
+
 @app.route('/api/car', methods=['POST'])
 def car_data():
     try:

--- a/Transmitter/car_dashboard.html
+++ b/Transmitter/car_dashboard.html
@@ -7,6 +7,25 @@
         body { font-family: Arial, sans-serif; background: #111; color: #eee; padding: 20px; }
         #data { margin-bottom: 20px; }
         video { max-width: 100%; height: auto; }
+        #controls {
+            display: inline-grid;
+            grid-template-areas:
+                '. up .'
+                'left stop right'
+                '. down .';
+            gap: 5px;
+            margin-top: 20px;
+        }
+        #controls button {
+            width: 40px;
+            height: 40px;
+            font-size: 18px;
+        }
+        #up { grid-area: up; }
+        #down { grid-area: down; }
+        #left { grid-area: left; }
+        #right { grid-area: right; }
+        #stop { grid-area: stop; }
     </style>
 </head>
 <body>
@@ -18,15 +37,18 @@
         <p>Distances: <span id="distances">-</span></p>
     </div>
     <video id="video" controls src="http://localhost:5001/api/video"></video>
+    <div id="controls">
+        <button id="up">&#8593;</button>
+        <button id="left">&#8592;</button>
+        <button id="stop">&#9632;</button>
+        <button id="right">&#8594;</button>
+        <button id="down">&#8595;</button>
+    </div>
 
     <script>
         async function fetchData() {
             try {
-                const res = await fetch('http://localhost:5001/api/car', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({}) // leeres Objekt, um POST auszulösen
-                });
+                const res = await fetch('http://localhost:5001/api/car');
                 if (!res.ok) return;
                 const data = await res.json();
                 document.getElementById('speed').textContent = data.speed;
@@ -39,6 +61,24 @@
         }
         setInterval(fetchData, 1000);
         fetchData();
+
+        async function sendCommand(action) {
+            try {
+                await fetch('http://localhost:5002/api/control', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action })
+                });
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
+        document.getElementById('up').addEventListener('click', () => sendCommand('up'));
+        document.getElementById('down').addEventListener('click', () => sendCommand('down'));
+        document.getElementById('left').addEventListener('click', () => sendCommand('left'));
+        document.getElementById('right').addEventListener('click', () => sendCommand('right'));
+        document.getElementById('stop').addEventListener('click', () => sendCommand('stop'));
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `GET /api/car` in simulation service so the dashboard's fetches succeed

## Testing
- `python -m py_compile Backend/control_api.py Backend/car_api.py Backend/asset_api.py Backend/map_api.py SimulateAsset/car_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68486bd8d4d08331aaaa897043744951