### PR TITLE
Implement control polling and GET endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ python SimulateAsset/control_api.py
 
 This service listens on port `5002` as well.
 
+`GET /api/control` returns the last command that was received:
+
+```bash
+curl http://localhost:5002/api/control
+```
+
+responds with
+
+```json
+{"action": "forward"}
+```
+
+### Control Unit and Map 2
+
+`Transmitter/control_unit.html` provides a small UI with arrow buttons that send
+commands to `/api/control`. The simulation in `SimulateAsset/map2.html` polls
+this endpoint periodically (every 200&nbsp;ms) to obtain the last command and
+maps it to the arrow keys of the virtual car. When both pages are open you can
+steer the vehicle in Map&nbsp;2 with the control unit.
+
 ### API Ports
 
 - `Backend/map_api.py` – 5000

--- a/SimulateAsset/car.js
+++ b/SimulateAsset/car.js
@@ -42,6 +42,22 @@ export class Car {
     window.addEventListener('keyup', e => {
       if (e.key in this.keys) this.keys[e.key] = false;
     });
+
+    this.actionMap = {
+      forward: 'ArrowUp',
+      up: 'ArrowUp',
+      backward: 'ArrowDown',
+      down: 'ArrowDown',
+      left: 'ArrowLeft',
+      right: 'ArrowRight',
+      stop: null
+    };
+  }
+
+  setKeysFromAction(action) {
+    for (const k of Object.keys(this.keys)) this.keys[k] = false;
+    const key = this.actionMap[action];
+    if (key) this.keys[key] = true;
   }
 
   drawBorder(canvasWidth, canvasHeight) {

--- a/SimulateAsset/control_api.py
+++ b/SimulateAsset/control_api.py
@@ -37,6 +37,12 @@ def control_car():
     controller.execute(action)
     return jsonify({'status': 'ok', 'action': controller.last_action})
 
+
+@app.route('/api/control', methods=['GET'])
+def get_last_action():
+    """Return the last control command that was sent."""
+    return jsonify({'action': controller.last_action})
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5002, debug=True)
 

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -24,6 +24,19 @@ const gyroEl = document.getElementById('gyro');
 const TELEMETRY_INTERVAL = 500; // ms
 let lastTelemetry = 0;
 
+const CONTROL_POLL_INTERVAL = 200; // ms
+
+async function pollControl() {
+  try {
+    const res = await fetch('http://localhost:5002/api/control');
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data.action) car.setKeysFromAction(data.action);
+  } catch (err) {
+    console.error('pollControl failed', err);
+  }
+}
+
 function sendTelemetry(front, rear, left, right) {
   fetch('http://127.0.0.1:5001/api/car', {
     method: 'POST',
@@ -291,4 +304,10 @@ document.getElementById('setSizeBtn').addEventListener('click', () => {
   generateBorder(gameMap, respawnTarget);
 });
 
-carImage.onload = () => { resizeCanvas(); document.getElementById('fetchMaps').click(); loop(); };
+carImage.onload = () => {
+  resizeCanvas();
+  document.getElementById('fetchMaps').click();
+  setInterval(pollControl, CONTROL_POLL_INTERVAL);
+  pollControl();
+  loop();
+};


### PR DESCRIPTION
## Summary
- handle remote control actions via `pollControl` in the simulator
- map actions to key presses in `Car`
- expose `GET /api/control` in the control API
- document how the Control Unit interacts with Map 2

## Testing
- `python -m py_compile SimulateAsset/control_api.py`

------
https://chatgpt.com/codex/tasks/task_e_684877651ad88331b9fdf69c654bb386