### PR TITLE
Add multi-key car control

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ values, e.g.:
 
 The JavaScript simulation posts its calculated data to `/api/car` so that
 `Transmitter/car_dashboard.html` can show the live telemetry values. Open this
-HTML file in your browser to see the dashboard and use the arrow cross to send
-movement commands.
+HTML file in your browser to see the dashboard and use the arrow cross or the
+keyboard to send movement commands.
 
 
 ## Car Control API
@@ -125,19 +125,18 @@ movement commands to the vehicle. Start it with:
 python SimulateAsset/control_api.py
 ```
 
-It runs on port `5002` and accepts POST requests to `/api/control` with an
-`action` field:
+It runs on port `5002` and accepts POST requests to `/api/control` with a
+`keys` object describing which control buttons are pressed:
 
 ```bash
 curl -X POST http://localhost:5002/api/control \
      -H "Content-Type: application/json" \
-     -d '{"action": "forward"}'
+     -d '{"keys": {"up": true, "left": true}}'
 ```
 
-Valid actions are `forward`, `backward`, `left`, `right` and `stop` (the values
-`up` and `down` are accepted as synonyms for `forward` and `backward`). The
-implementation simply records the last action; integration with actual hardware
-can be added where indicated in the code.
+Each key (`up`, `down`, `left`, `right`) is optional and maps to the
+corresponding arrow key of the simulated car. This allows multiple directions to
+be active at once.
 
 For the JavaScript simulation the same API is provided in
 `SimulateAsset/control_api.py`. Start it with:
@@ -148,7 +147,7 @@ python SimulateAsset/control_api.py
 
 This service listens on port `5002` as well.
 
-`GET /api/control` returns the last command that was received:
+`GET /api/control` returns the current key state:
 
 ```bash
 curl http://localhost:5002/api/control
@@ -157,16 +156,17 @@ curl http://localhost:5002/api/control
 responds with
 
 ```json
-{"action": "forward"}
+{"keys": {"up": true, "left": false, "right": false, "down": false}}
 ```
 
 ### Control Unit and Map 2
 
-`Transmitter/control_unit.html` provides a small UI with arrow buttons that send
-commands to `/api/control`. The simulation in `SimulateAsset/map2.html` polls
-this endpoint periodically (every 200&nbsp;ms) to obtain the last command and
-maps it to the arrow keys of the virtual car. When both pages are open you can
-steer the vehicle in Map&nbsp;2 with the control unit.
+`Transmitter/control_unit.html` provides a small UI with arrow buttons and
+keyboard support that send the pressed key state to `/api/control`. The
+simulation in `SimulateAsset/map2.html` polls this endpoint periodically (every
+200&nbsp;ms) and applies the key state to the virtual car. When both pages are
+open you can steer the vehicle in Map&nbsp;2 with the control unit, including
+multiple keys at once.
 
 ### API Ports
 

--- a/SimulateAsset/car.js
+++ b/SimulateAsset/car.js
@@ -60,6 +60,12 @@ export class Car {
     if (key) this.keys[key] = true;
   }
 
+  setKeys(state) {
+    for (const k of Object.keys(this.keys)) {
+      if (k in state) this.keys[k] = !!state[k];
+    }
+  }
+
   drawBorder(canvasWidth, canvasHeight) {
     const m = this.margin;
     this.ctx.fillStyle = '#aaa';

--- a/SimulateAsset/control_api.py
+++ b/SimulateAsset/control_api.py
@@ -6,41 +6,65 @@ CORS(app)
 
 class CarController:
     """Placeholder controller that would talk to the real vehicle."""
-    def __init__(self):
-        self.last_action = None
 
-    def execute(self, action: str):
-        # Integration with actual car hardware would happen here.
-        self.last_action = action
+    def __init__(self):
+        self.keys = {k: False for k in ['up', 'down', 'left', 'right']}
+
+    def set_single_action(self, action: str):
+        """Set only one key based on a legacy action value."""
+        mapping = {
+            'forward': 'up',
+            'backward': 'down',
+            'left': 'left',
+            'right': 'right',
+            'stop': None,
+            # allow arrow style synonyms
+            'up': 'up',
+            'down': 'down',
+        }
+        key = mapping.get(action)
+        if key is None and action != 'stop':
+            return False
+        for k in self.keys:
+            self.keys[k] = (k == key) if key else False
+        return True
+
+    def update_keys(self, updates: dict):
+        """Update multiple key states."""
+        for k, v in updates.items():
+            if k in self.keys:
+                self.keys[k] = bool(v)
+        return True
+
+    def get_state(self):
+        return self.keys
 
 controller = CarController()
 
 VALID_ACTIONS = {
-    'forward': 'forward',
-    'backward': 'backward',
-    'left': 'left',
-    'right': 'right',
-    'stop': 'stop',
-    # allow arrow style synonyms
-    'up': 'forward',
-    'down': 'backward',
+    'forward', 'backward', 'left', 'right', 'stop', 'up', 'down'
 }
 
 @app.route('/api/control', methods=['POST'])
 def control_car():
     data = request.get_json() or {}
+    # new multi-key interface
+    if isinstance(data.get('keys'), dict):
+        controller.update_keys(data['keys'])
+        return jsonify({'status': 'ok', 'keys': controller.get_state()})
+
     raw_action = data.get('action')
-    action = VALID_ACTIONS.get(raw_action)
-    if action is None:
+    if raw_action not in VALID_ACTIONS:
         return jsonify({'error': 'invalid action'}), 400
-    controller.execute(action)
-    return jsonify({'status': 'ok', 'action': controller.last_action})
+    if not controller.set_single_action(raw_action):
+        return jsonify({'error': 'invalid action'}), 400
+    return jsonify({'status': 'ok', 'keys': controller.get_state()})
 
 
 @app.route('/api/control', methods=['GET'])
-def get_last_action():
-    """Return the last control command that was sent."""
-    return jsonify({'action': controller.last_action})
+def get_keys():
+    """Return the current key state."""
+    return jsonify({'keys': controller.get_state()})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5002, debug=True)

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -31,7 +31,12 @@ async function pollControl() {
     const res = await fetch('http://localhost:5002/api/control');
     if (!res.ok) return;
     const data = await res.json();
-    if (data.action) car.setKeysFromAction(data.action);
+    if (data.keys) {
+      car.setKeys(data.keys);
+    } else if (data.action) {
+      // backwards compatibility
+      car.setKeysFromAction(data.action);
+    }
   } catch (err) {
     console.error('pollControl failed', err);
   }

--- a/Transmitter/car_dashboard.html
+++ b/Transmitter/car_dashboard.html
@@ -62,23 +62,48 @@
         setInterval(fetchData, 1000);
         fetchData();
 
-        async function sendCommand(action) {
+        const keys = {up: false, down: false, left: false, right: false};
+
+        async function sendKeys() {
             try {
                 await fetch('http://localhost:5002/api/control', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action })
+                    body: JSON.stringify({ keys })
                 });
             } catch (e) {
                 console.error(e);
             }
         }
 
-        document.getElementById('up').addEventListener('click', () => sendCommand('up'));
-        document.getElementById('down').addEventListener('click', () => sendCommand('down'));
-        document.getElementById('left').addEventListener('click', () => sendCommand('left'));
-        document.getElementById('right').addEventListener('click', () => sendCommand('right'));
-        document.getElementById('stop').addEventListener('click', () => sendCommand('stop'));
+        function setKey(k, val) {
+            if (keys[k] === val) return;
+            keys[k] = val;
+            sendKeys();
+        }
+
+        const btnMap = {up: 'ArrowUp', down: 'ArrowDown', left: 'ArrowLeft', right: 'ArrowRight'};
+        const keyToName = {ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right'};
+        for (const name of Object.keys(btnMap)) {
+            const el = document.getElementById(name);
+            el.addEventListener('mousedown', () => setKey(name, true));
+            el.addEventListener('mouseup', () => setKey(name, false));
+            el.addEventListener('mouseleave', () => setKey(name, false));
+            el.addEventListener('touchstart', e => { e.preventDefault(); setKey(name, true); });
+            el.addEventListener('touchend', () => setKey(name, false));
+        }
+
+        document.getElementById('stop').addEventListener('click', () => {
+            for (const k of Object.keys(keys)) keys[k] = false;
+            sendKeys();
+        });
+
+        document.addEventListener('keydown', e => {
+            if (e.key in keyToName) setKey(keyToName[e.key], true);
+        });
+        document.addEventListener('keyup', e => {
+            if (e.key in keyToName) setKey(keyToName[e.key], false);
+        });
     </script>
 </body>
 </html>

--- a/Transmitter/control_unit.html
+++ b/Transmitter/control_unit.html
@@ -37,23 +37,48 @@
     </div>
 
     <script>
-        async function sendCommand(action) {
+        const keys = {up: false, down: false, left: false, right: false};
+
+        async function sendKeys() {
             try {
                 await fetch('http://localhost:5002/api/control', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action })
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({keys})
                 });
             } catch (e) {
                 console.error(e);
             }
         }
 
-        document.getElementById('up').addEventListener('click', () => sendCommand('up'));
-        document.getElementById('down').addEventListener('click', () => sendCommand('down'));
-        document.getElementById('left').addEventListener('click', () => sendCommand('left'));
-        document.getElementById('right').addEventListener('click', () => sendCommand('right'));
-        document.getElementById('stop').addEventListener('click', () => sendCommand('stop'));
+        function setKey(k, val) {
+            if (keys[k] === val) return;
+            keys[k] = val;
+            sendKeys();
+        }
+
+        const btnMap = {up: 'ArrowUp', down: 'ArrowDown', left: 'ArrowLeft', right: 'ArrowRight'};
+        const keyToName = {ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right'};
+        for (const name of Object.keys(btnMap)) {
+            const el = document.getElementById(name);
+            el.addEventListener('mousedown', () => setKey(name, true));
+            el.addEventListener('mouseup', () => setKey(name, false));
+            el.addEventListener('mouseleave', () => setKey(name, false));
+            el.addEventListener('touchstart', e => { e.preventDefault(); setKey(name, true); });
+            el.addEventListener('touchend', () => setKey(name, false));
+        }
+
+        document.getElementById('stop').addEventListener('click', () => {
+            for (const k of Object.keys(keys)) keys[k] = false;
+            sendKeys();
+        });
+
+        document.addEventListener('keydown', e => {
+            if (e.key in keyToName) setKey(keyToName[e.key], true);
+        });
+        document.addEventListener('keyup', e => {
+            if (e.key in keyToName) setKey(keyToName[e.key], false);
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support multi-key control in `control_api.py`
- use key state in the simulation and car class
- allow keyboard + button control on `control_unit.html` and `car_dashboard.html`
- document updated control API

## Testing
- `python -m py_compile SimulateAsset/control_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68487acb8d2083318ccbc92bc989cd22