### PR TITLE
Add optimal pathfinder for map2 simulation

### DIFF
--- a/SimulateAsset/map2.html
+++ b/SimulateAsset/map2.html
@@ -90,6 +90,7 @@
     <button id="deleteMapBtn">Delete</button>
     <button id="saveMap">Download Map</button>
     <button id="loadMapBtn">Load Map</button>
+    <button id="calcPathBtn">Optimal Pathfinder</button>
     <input type="file" id="loadMap" style="display:none" accept="application/json">
   </div>
   <canvas id="canvas"></canvas>

--- a/SimulateAsset/mapGenerator.js
+++ b/SimulateAsset/mapGenerator.js
@@ -33,14 +33,19 @@ export function generateMaze(gameMap, respawnTarget) {
   let y = 1;
   while (y < rows - 1) {
     const h = Math.floor(Math.random() * (maxPassage - minPassage + 1)) + minPassage;
-    for (let x = 1; x < cols - 1; x++) if (Math.random() < 0.3) {
-      const ox = x * cellSize;
-      const oy = y * cellSize;
-      if (target && target.intersectsRect(ox, oy, cellSize, cellSize)) {
-        if (typeof respawnTarget === 'function') respawnTarget();
-        else continue;
+    for (let x = 3; x < cols - 3;) {
+      if (Math.random() < 0.3) {
+        const ox = x * cellSize;
+        const oy = y * cellSize;
+        if (target && target.intersectsRect(ox, oy, cellSize, cellSize)) {
+          if (typeof respawnTarget === 'function') respawnTarget();
+          else { x++; continue; }
+        }
+        obstacles.push(new Obstacle(ox, oy, cellSize));
+        x += 3; // leave at least two cells free after each obstacle
+      } else {
+        x++;
       }
-      obstacles.push(new Obstacle(ox, oy, cellSize));
     }
     y += h;
     if (y < rows - 1) {


### PR DESCRIPTION
## Summary
- add 'Optimal Pathfinder' button to map2.html controls
- implement A* search in main.js to calculate path on grid
- draw calculated path in blue on the canvas
- clear stored path when map or target changes
- require corridors at least two grid cells wide
- update maze generation to avoid 1-cell wide passages

## Testing
- `node --check SimulateAsset/main.js`
- `python -m py_compile Backend/*.py Transmitter/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6848ba2941488331887821c1d68149e5