### PR TITLE
Add autopilot path follower

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ movement commands.
 
 ## Car Control API
 
-A separate Flask service is provided in `SimulateAsset/control_api.py` for sending
+A separate Flask service is provided in `Transmitter/control_api.py` for sending
 movement commands to the vehicle. Start it with:
 
 ```bash
-python SimulateAsset/control_api.py
+python Transmitter/control_api.py
 ```
 
 It runs on port `5002` and accepts POST requests to `/api/control` with an
@@ -140,10 +140,10 @@ implementation simply records the last action; integration with actual hardware
 can be added where indicated in the code.
 
 For the JavaScript simulation the same API is provided in
-`SimulateAsset/control_api.py`. Start it with:
+`Transmitter/control_api.py`. Start it with:
 
 ```bash
-python SimulateAsset/control_api.py
+python Transmitter/control_api.py
 ```
 
 This service listens on port `5002` as well.
@@ -168,8 +168,22 @@ this endpoint periodically (every 200&nbsp;ms) to obtain the last command and
 maps it to the arrow keys of the virtual car. When both pages are open you can
 steer the vehicle in Map&nbsp;2 with the control unit.
 
+### Autopilot
+
+1. Start the control API if it is not already running:
+
+   ```bash
+   python Transmitter/control_api.py
+   ```
+
+2. Open `SimulateAsset/map2.html` in a browser.
+3. Place obstacles and a target, then click **Optimal Pathfinder**.
+4. The script calculates a path and automatically issues movement commands
+   through the control API. Manual keyboard input is ignored until the route is
+   finished.
+
 ### API Ports
 
 - `Backend/map_api.py` – 5000
 - `SimulateAsset/car_api.py` – 5001
-- `SimulateAsset/control_api.py` – 5002
+- `Transmitter/control_api.py` – 5002

--- a/SimulateAsset/car.js
+++ b/SimulateAsset/car.js
@@ -29,6 +29,7 @@ export class Car {
     this.rpm = 0;
     this.gyro = 0;
 
+    this.autopilot = false;
     this.keys = {
       ArrowUp: false,
       ArrowDown: false,
@@ -37,10 +38,10 @@ export class Car {
     };
 
     window.addEventListener('keydown', e => {
-      if (e.key in this.keys) this.keys[e.key] = true;
+      if (!this.autopilot && e.key in this.keys) this.keys[e.key] = true;
     });
     window.addEventListener('keyup', e => {
-      if (e.key in this.keys) this.keys[e.key] = false;
+      if (!this.autopilot && e.key in this.keys) this.keys[e.key] = false;
     });
 
     this.actionMap = {

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -60,6 +60,45 @@ let dragX = 0;
 let dragY = 0;
 let targetMarker = gameMap.target;
 let pathCells = [];
+let autopilotRunning = false;
+
+async function followPath() {
+  if (autopilotRunning || pathCells.length < 2) return;
+  autopilotRunning = true;
+  car.autopilot = true;
+  for (let i = 0; i < pathCells.length - 1; i++) {
+    const cur = pathCells[i];
+    const next = pathCells[i + 1];
+    let action = null;
+    if (next.x > cur.x) action = 'right';
+    else if (next.x < cur.x) action = 'left';
+    else if (next.y > cur.y) action = 'down';
+    else if (next.y < cur.y) action = 'up';
+    if (action) {
+      try {
+        await fetch('http://localhost:5002/api/control', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action })
+        });
+      } catch (err) {
+        console.error('followPath failed', err);
+      }
+      await new Promise(r => setTimeout(r, 300));
+    }
+  }
+  try {
+    await fetch('http://localhost:5002/api/control', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'stop' })
+    });
+  } catch (err) {
+    console.error('followPath stop failed', err);
+  }
+  car.autopilot = false;
+  autopilotRunning = false;
+}
 
 function refreshCarObjects() {
   // Only obstacles should block the car. The target is handled
@@ -405,6 +444,7 @@ calcPathBtn.addEventListener('click', () => {
   goal.x = Math.min(goal.x, gameMap.cols - 2);
   goal.y = Math.min(goal.y, gameMap.rows - 2);
   pathCells = aStar(start, goal);
+  followPath();
 });
 
 carImage.onload = () => {


### PR DESCRIPTION
## Summary
- implement autopilot support in `main.js` to send commands via `/api/control`
- disable keyboard input while autopilot runs
- update control API path and add autopilot usage notes in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848c3f9ff98833199a9b319bc8e5613