### PR TITLE
Add speed limit endpoints

### DIFF
--- a/Backend/car_api.py
+++ b/Backend/car_api.py
@@ -3,6 +3,8 @@ from flask_cors import CORS
 import os
 import random
 
+MAX_TOTAL_SPEED = 30
+
 app = Flask(__name__)
 CORS(app)
 
@@ -11,6 +13,7 @@ class Car:
         self.speed = 0.0
         self.rpm = 0
         self.gyro = 0.0
+        self.max_speed = MAX_TOTAL_SPEED
         self.distances = {
             'front': 0,
             'rear': 0,
@@ -21,7 +24,7 @@ class Car:
     def control(self, action):
         """Very small state change based on a simple action."""
         if action == 'up':
-            self.speed = min(self.speed + 1, 30)
+            self.speed = min(self.speed + 1, self.max_speed)
             self.rpm = int(self.speed * 100)
         elif action == 'down':
             self.speed = max(self.speed - 1, 0)
@@ -36,7 +39,7 @@ class Car:
 
     def update_random(self):
         """Fill the fields with some random demo values."""
-        self.speed = round(random.uniform(0, 30), 2)
+        self.speed = round(random.uniform(0, self.max_speed), 2)
         self.rpm = int(self.speed * 100)
         self.gyro = round(random.uniform(0, 360), 1)
         self.distances = {k: int(random.uniform(0, 150)) for k in self.distances}

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The service listens on port `5001` and provides these endpoints:
 - `GET /api/car` – return the current telemetry values
 - `POST /api/car` – update the telemetry state with a JSON payload
 - `GET /api/video` – stream `dummy-video.mp4` if it is present
+- `GET /api/speed` – return the current speed limit
+- `POST /api/speed` – set a new speed limit (body: `{"max_speed": 20}`)
 
 Example data sent to `POST /api/car`:
 
@@ -147,6 +149,9 @@ python SimulateAsset/control_api.py
 ```
 
 This service listens on port `5002` as well.
+
+`GET /api/speed` returns the configured speed limit and `POST /api/speed` sets a
+new limit (JSON `{"max_speed": 20}`).
 
 `GET /api/control` returns the last command that was received:
 

--- a/Transmitter/control_api.py
+++ b/Transmitter/control_api.py
@@ -1,6 +1,8 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 
+MAX_TOTAL_SPEED = 30
+
 app = Flask(__name__)
 CORS(app)
 
@@ -8,6 +10,7 @@ class CarController:
     """Placeholder controller that would talk to the real vehicle."""
     def __init__(self):
         self.last_action = None
+        self.max_speed = MAX_TOTAL_SPEED
 
     def execute(self, action: str):
         # Integration with actual car hardware would happen here.
@@ -41,6 +44,21 @@ def control_car():
 def get_last_action():
     """Return the last control command that was sent."""
     return jsonify({'action': controller.last_action})
+
+
+@app.route('/api/speed', methods=['GET', 'POST'])
+def speed_limit():
+    if request.method == 'GET':
+        return jsonify({'max_speed': controller.max_speed})
+    data = request.get_json() or {}
+    try:
+        value = float(data.get('max_speed'))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'invalid value'}), 400
+    if value > MAX_TOTAL_SPEED:
+        return jsonify({'error': 'exceeds limit'}), 400
+    controller.max_speed = value
+    return jsonify({'max_speed': controller.max_speed})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5002, debug=True)

--- a/Transmitter/control_unit.html
+++ b/Transmitter/control_unit.html
@@ -14,6 +14,7 @@
 </head>
 <body>
     <h1>Control Unit (Use Arrow Keys)</h1>
+    <p>Max Speed: <input type="number" id="maxSpeedInput" min="0" max="30"></p>
 
     <script>
         let currentAction = null;
@@ -45,6 +46,30 @@
                 console.error(e);
             }
         };
+
+        async function fetchSpeed() {
+            try {
+                const res = await fetch('http://localhost:5002/api/speed');
+                if (!res.ok) return;
+                const data = await res.json();
+                document.getElementById('maxSpeedInput').value = data.max_speed;
+            } catch (e) {
+                console.error(e);
+            }
+        }
+        fetchSpeed();
+
+        document.getElementById('maxSpeedInput').addEventListener('change', async (e) => {
+            try {
+                await fetch('http://localhost:5002/api/speed', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ max_speed: parseFloat(e.target.value) })
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        });
 
         document.addEventListener('keydown', (e) => {
             switch (e.key) {

--- a/Transmitter/dashboard.html
+++ b/Transmitter/dashboard.html
@@ -35,6 +35,7 @@
         <p>RPM: <span id="rpm">-</span></p>
         <p>Gyro: <span id="gyro">-</span>°</p>
         <p>Distances: <span id="distances">-</span></p>
+        <p>Max Speed: <input type="number" id="maxSpeedInput" min="0" max="30"></p>
     </div>
     <!-- <video id="video" controls src="http://localhost:5001/api/video"></video> -->
     <video src="dummy-video.mp4" controls></video>
@@ -63,6 +64,30 @@
         }
         setInterval(fetchData, 1000);
         fetchData();
+
+        async function fetchSpeed() {
+            try {
+                const res = await fetch('http://localhost:5001/api/speed');
+                if (!res.ok) return;
+                const data = await res.json();
+                document.getElementById('maxSpeedInput').value = data.max_speed;
+            } catch (e) {
+                console.error(e);
+            }
+        }
+        fetchSpeed();
+
+        document.getElementById('maxSpeedInput').addEventListener('change', async (e) => {
+            try {
+                await fetch('http://localhost:5001/api/speed', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ max_speed: parseFloat(e.target.value) })
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        });
 
         async function sendCommand(action) {
             try {

--- a/Transmitter/dashoboard_api.py
+++ b/Transmitter/dashoboard_api.py
@@ -2,6 +2,8 @@ from flask import Flask, jsonify, send_from_directory, request
 from flask_cors import CORS
 import os
 
+MAX_TOTAL_SPEED = 30
+
 app = Flask(__name__)
 CORS(app)
 
@@ -10,6 +12,7 @@ class Car:
         self.speed = 0.0
         self.rpm = 0
         self.gyro = 0.0
+        self.max_speed = MAX_TOTAL_SPEED
         self.distances = {
             'front': 0,
             'rear': 0,
@@ -55,6 +58,21 @@ def car_data():
         })
     except Exception as e:
         return jsonify({'error': str(e)}), 400
+
+
+@app.route('/api/speed', methods=['GET', 'POST'])
+def speed_limit():
+    if request.method == 'GET':
+        return jsonify({'max_speed': car.max_speed})
+    data = request.get_json() or {}
+    try:
+        value = float(data.get('max_speed'))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'invalid value'}), 400
+    if value > MAX_TOTAL_SPEED:
+        return jsonify({'error': 'exceeds limit'}), 400
+    car.max_speed = value
+    return jsonify({'max_speed': car.max_speed})
 
 @app.route('/api/video', methods=['GET'])
 def get_video():


### PR DESCRIPTION
## Summary
- support configurable max speed in backend and transmitter APIs
- expose new GET/POST /api/speed endpoint
- add speed limit controls to dashboard and control unit UIs
- document the new API routes

## Testing
- `python -m py_compile Backend/car_api.py Transmitter/dashoboard_api.py Transmitter/control_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cd44e69083318be2df733bc3b989