### PR TITLE
Add position telemetry and simple grid map

### DIFF
--- a/Backend/car_api.py
+++ b/Backend/car_api.py
@@ -13,6 +13,8 @@ class Car:
         self.speed = 0.0
         self.rpm = 0
         self.gyro = 0.0
+        self.pos_x = 0.0
+        self.pos_y = 0.0
         self.max_speed = MAX_TOTAL_SPEED
         self.distances = {
             'front': 0,
@@ -42,6 +44,8 @@ class Car:
         self.speed = round(random.uniform(0, self.max_speed), 2)
         self.rpm = int(self.speed * 100)
         self.gyro = round(random.uniform(0, 360), 1)
+        self.pos_x = round(random.uniform(0, 100), 2)
+        self.pos_y = round(random.uniform(0, 100), 2)
         self.distances = {k: int(random.uniform(0, 150)) for k in self.distances}
 
     def update_from_dict(self, data):
@@ -49,6 +53,8 @@ class Car:
         self.speed = float(data.get('speed', self.speed))
         self.rpm = int(data.get('rpm', self.rpm))
         self.gyro = float(data.get('gyro', self.gyro))
+        self.pos_x = float(data.get('pos_x', self.pos_x))
+        self.pos_y = float(data.get('pos_y', self.pos_y))
         distances = data.get('distances', {})
         for k in self.distances.keys():
             if k in distances:
@@ -62,6 +68,8 @@ def get_car_data():
         'speed': car.speed,
         'rpm': car.rpm,
         'gyro': car.gyro,
+        'pos_x': car.pos_x,
+        'pos_y': car.pos_y,
         'distances': car.distances
     })
 
@@ -69,7 +77,7 @@ def get_car_data():
 @app.route('/api/car', methods=['POST'])
 def set_car_data():
     data = request.get_json() or {}
-    required = ['speed', 'rpm', 'gyro', 'distances']
+    required = ['speed', 'rpm', 'gyro', 'pos_x', 'pos_y', 'distances']
     if not all(k in data for k in required):
         return jsonify({'error': 'invalid payload'}), 400
     distances = data['distances']

--- a/SimulateAsset/main.js
+++ b/SimulateAsset/main.js
@@ -46,6 +46,8 @@ function sendTelemetry(front, rear, left, right) {
       speed: car.speed,
       rpm: car.rpm,
       gyro: car.gyro,
+      pos_x: car.posX,
+      pos_y: car.posY,
       distances: { front, rear, left, right }
     })
   }).catch(err => console.error('sendTelemetry failed', err));

--- a/Transmitter/dashboard.html
+++ b/Transmitter/dashboard.html
@@ -26,6 +26,7 @@
         #left { grid-area: left; }
         #right { grid-area: right; }
         #stop { grid-area: stop; }
+        #gridCanvas { background: #222; border: 1px solid #555; margin-top: 20px; }
     </style>
 </head>
 <body>
@@ -37,6 +38,7 @@
         <p>Distances: <span id="distances">-</span></p>
         <p>Max Speed: <input type="number" id="maxSpeedInput" min="0" max="30"></p>
     </div>
+    <canvas id="gridCanvas"></canvas>
     <!-- <video id="video" controls src="http://localhost:5001/api/video"></video> -->
     <video src="dummy-video.mp4" controls></video>
 
@@ -49,6 +51,74 @@
     </div>
 
     <script>
+        const GRID_COLS = 20;
+        const GRID_ROWS = 15;
+        const CELL_SIZE = 40;
+
+        class GridMap {
+            constructor(cols, rows) {
+                this.cols = cols;
+                this.rows = rows;
+                this.cellSize = CELL_SIZE;
+                this.cells = Array.from({length: rows}, () =>
+                    Array.from({length: cols}, () => ({ explored: false, obstacle: false })));
+            }
+            inBounds(x, y) { return x >= 0 && x < this.cols && y >= 0 && y < this.rows; }
+        }
+
+        const grid = new GridMap(GRID_COLS, GRID_ROWS);
+        const canvas = document.getElementById('gridCanvas');
+        const gctx = canvas.getContext('2d');
+        canvas.width = GRID_COLS * CELL_SIZE;
+        canvas.height = GRID_ROWS * CELL_SIZE;
+        let lastPos = null;
+
+        function drawGrid() {
+            for (let y = 0; y < grid.rows; y++) {
+                for (let x = 0; x < grid.cols; x++) {
+                    const cell = grid.cells[y][x];
+                    gctx.fillStyle = cell.obstacle ? '#f00' : cell.explored ? '#555' : '#222';
+                    gctx.fillRect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE - 1, CELL_SIZE - 1);
+                }
+            }
+            if (lastPos) {
+                gctx.fillStyle = '#0f0';
+                gctx.fillRect(lastPos.x * CELL_SIZE + CELL_SIZE / 4,
+                               lastPos.y * CELL_SIZE + CELL_SIZE / 4,
+                               CELL_SIZE / 2, CELL_SIZE / 2);
+            }
+        }
+
+        function updateGridFromSensors(pos, distances) {
+            const cx = Math.floor(pos.x / CELL_SIZE);
+            const cy = Math.floor(pos.y / CELL_SIZE);
+            if (grid.inBounds(cx, cy)) {
+                grid.cells[cy][cx].explored = true;
+                lastPos = { x: cx, y: cy };
+            }
+            const dirs = [
+                {dx: 0, dy: -1, dist: distances.front},
+                {dx: 0, dy: 1, dist: distances.rear},
+                {dx: -1, dy: 0, dist: distances.left},
+                {dx: 1, dy: 0, dist: distances.right}
+            ];
+            for (const d of dirs) {
+                const steps = Math.floor(d.dist / CELL_SIZE);
+                for (let i = 1; i <= steps; i++) {
+                    const x = cx + d.dx * i;
+                    const y = cy + d.dy * i;
+                    if (!grid.inBounds(x, y)) break;
+                    grid.cells[y][x].explored = true;
+                }
+                const ox = cx + d.dx * steps;
+                const oy = cy + d.dy * steps;
+                if (grid.inBounds(ox, oy)) {
+                    grid.cells[oy][ox].obstacle = true;
+                }
+            }
+            drawGrid();
+        }
+
         async function fetchData() {
             try {
                 const res = await fetch('http://localhost:5001/api/car');
@@ -58,6 +128,9 @@
                 document.getElementById('rpm').textContent = data.rpm;
                 document.getElementById('gyro').textContent = data.gyro;
                 document.getElementById('distances').textContent = JSON.stringify(data.distances);
+                if (data.pos_x != null && data.pos_y != null) {
+                    updateGridFromSensors({x: data.pos_x, y: data.pos_y}, data.distances);
+                }
             } catch (e) {
                 console.error(e);
             }

--- a/Transmitter/dashoboard_api.py
+++ b/Transmitter/dashoboard_api.py
@@ -12,6 +12,8 @@ class Car:
         self.speed = 0.0
         self.rpm = 0
         self.gyro = 0.0
+        self.pos_x = 0.0
+        self.pos_y = 0.0
         self.max_speed = MAX_TOTAL_SPEED
         self.distances = {
             'front': 0,
@@ -24,6 +26,8 @@ class Car:
         self.speed = data.get('speed', self.speed)
         self.rpm = data.get('rpm', self.rpm)
         self.gyro = data.get('gyro', self.gyro)
+        self.pos_x = data.get('pos_x', self.pos_x)
+        self.pos_y = data.get('pos_y', self.pos_y)
         distances = data.get('distances')
         if isinstance(distances, dict):
             for k in ['front', 'rear', 'left', 'right']:
@@ -39,6 +43,8 @@ def get_car_data():
         'speed': car.speed,
         'rpm': car.rpm,
         'gyro': car.gyro,
+        'pos_x': car.pos_x,
+        'pos_y': car.pos_y,
         'distances': car.distances
     })
 
@@ -54,6 +60,8 @@ def car_data():
             'speed': car.speed,
             'rpm': car.rpm,
             'gyro': car.gyro,
+            'pos_x': car.pos_x,
+            'pos_y': car.pos_y,
             'distances': car.distances
         })
     except Exception as e:


### PR DESCRIPTION
## Summary
- store `pos_x` and `pos_y` for the simulated car
- include the position in backend APIs
- send car position from the JS simulation
- render a simple explored/obstacle grid on the dashboard

## Testing
- `python -m py_compile Backend/car_api.py Transmitter/dashoboard_api.py`
- `node --check SimulateAsset/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6848cee1e8e8833183138120cde3e8c8