### PR TITLE
Add advanced control maneuvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ curl -X POST http://localhost:5002/api/control \
      -d '{"action": "forward"}'
 ```
 
-Valid actions are `forward`, `backward`, `left`, `right` and `stop` (the values
-`up` and `down` are accepted as synonyms for `forward` and `backward`). The
-implementation simply records the last action; integration with actual hardware
-can be added where indicated in the code.
+Valid actions are `forward`, `backward`, `left`, `right` and `stop`. The values
+`up` and `down` are accepted as synonyms for `forward` and `backward`. Additional
+maneuvers include `align_left`, `align_right`, `align_up`, `align_down`,
+`curve_left`, `curve_right` and `circle`. The implementation simply records the
+last action; integration with actual hardware can be added where indicated in
+the code.
 
 For the JavaScript simulation the same API is provided in
 `SimulateAsset/control_api.py`. Start it with:

--- a/Transmitter/control_api.py
+++ b/Transmitter/control_api.py
@@ -11,10 +11,21 @@ class CarController:
     def __init__(self):
         self.last_action = None
         self.max_speed = MAX_TOTAL_SPEED
+        # keep a short history so advanced maneuvers can be processed later
+        self.history = []
 
     def execute(self, action: str):
         # Integration with actual car hardware would happen here.
+        # Record the action for potential processing
         self.last_action = action
+        self.history.append(action)
+        # Advanced maneuvers could trigger special routines here
+        if action in {
+            'align_left', 'align_right', 'align_up', 'align_down',
+            'curve_left', 'curve_right', 'circle'
+        }:
+            # Placeholder for servo or steering control logic
+            pass
 
 controller = CarController()
 
@@ -27,6 +38,14 @@ VALID_ACTIONS = {
     # allow arrow style synonyms
     'up': 'forward',
     'down': 'backward',
+    # additional maneuvers
+    'align_left': 'align_left',
+    'align_right': 'align_right',
+    'align_up': 'align_up',
+    'align_down': 'align_down',
+    'curve_left': 'curve_left',
+    'curve_right': 'curve_right',
+    'circle': 'circle',
 }
 
 @app.route('/api/control', methods=['POST'])


### PR DESCRIPTION
## Summary
- store executed maneuvers in `CarController`
- accept new actions like `align_left`, `curve_right`, `circle` and others
- document the extended action list in the README

## Testing
- `python -m py_compile Transmitter/control_api.py Backend/car_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cfc83e5c8331842dd136507db12a